### PR TITLE
Extending Component load paths

### DIFF
--- a/lib/NoFlo.coffee
+++ b/lib/NoFlo.coffee
@@ -123,3 +123,9 @@ exports.loadFile = (file, success) ->
 exports.Component = component.Component
 exports.Port = port.Port
 exports.graph = graph
+
+# Method for extending include paths for
+# NoFlo components
+exports.addComponentIncludePaths = (paths) ->
+  for path in paths
+    require.paths.unshift path


### PR DESCRIPTION
Helper method for extending require paths which NoFlo uses to find modules.
Usage:
noflo = require 'noflow'
noflow.addComponentIncludePaths ['/path1', '/path2']
