### PR TITLE
Do not spawn a compiler for every file.

### DIFF
--- a/Cakefile
+++ b/Cakefile
@@ -10,20 +10,10 @@ sh = (command) -> (k) ->
     console.log serr if serr
     do k
 
-buildFile = (parentPath, dir, file) ->
-  exec "coffee -o #{parentPath}/#{dir} -c #{parentPath}/src/#{dir}/#{file}", (err, stdout, stderr) ->
-    console.log stderr if stderr
-
 buildDir = (path) ->
   console.log "Compiling CoffeeScript from 'src/#{path}' to '#{path}"
-
-  fs.readdir "#{__dirname}/src/#{path}", (err, files) ->
-    return console.log err if err
-    files.forEach (file) ->
-      fs.stat "#{__dirname}/src/#{path}/#{file}", (err, stats) ->
-        return buildFile __dirname, path, file if file.indexOf(".coffee") isnt -1
-        return unless stats.isDirectory()
-        buildDir "#{path}/#{file}"
+  exec "coffee -c -o #{__dirname}/#{path} #{__dirname}/src/#{path}", (err, stdout, stderr) ->
+    console.log stderr if stderr
 
 task 'build', 'transpile CoffeeScript sources to JavaScript', ->
   buildDir "lib"


### PR DESCRIPTION
I was getting an EMFILE (too many open files) with the current approach of spawning a coffee process for every file (see below). This changes the Cakefile to compile each source directory all at once.

```
child_process.js:444
    throw errnoException(errno, 'spawn');
    ^
Error: spawn EMFILE
    at errnoException (child_process.js:481:11)
    at ChildProcess.spawn (child_process.js:444:11)
    at child_process.js:342:9
    at Object.execFile (child_process.js:252:15)
    at child_process.js:220:18
    at /Users/ryanshaw/Code/noflo/Cakefile:29:12
    at Object.oncomplete (/Users/ryanshaw/Code/noflo/Cakefile:45:20)
```
