### PR TITLE
Added Throttle component.

### DIFF
--- a/src/components/Throttle.coffee
+++ b/src/components/Throttle.coffee
@@ -1,0 +1,48 @@
+noflo = require "noflo"
+util = require "util"
+
+class Throttle extends noflo.Component
+
+    constructor: ->
+        @inPorts =
+            in: new noflo.Port()
+            load: new noflo.Port()
+            max: new noflo.Port()
+        @outPorts =
+            out: new noflo.Port()
+
+        @q = []
+        @load = 0
+        @max = 10
+
+        @inPorts.load.on "data", (data) =>
+            @load = data
+            @process()
+
+        @inPorts.max.on "data", (data) =>
+            @max = data
+            @process()
+
+        @inPorts.in.on "begingroup", (group) =>
+            @push "begingroup", group
+        @inPorts.in.on "data", (data) =>
+            @push "data", data
+        @inPorts.in.on "endgroup", =>
+            @push "endgroup"
+        @inPorts.in.on "disconnect", =>
+            @push "disconnect"
+
+    push: (eventname, data) ->
+        @q.push { name: eventname, data: data }
+        @process()
+
+    process: ->
+        while @q.length > 0 and @load < @max
+            event = @q.shift()
+            switch event.name
+                when "begingroup" then @outPorts.out.beginGroup event.data
+                when "data" then @outPorts.out.send event.data
+                when "endgroup" then @outPorts.out.endGroup()
+                when "disconnect" then @outPorts.out.disconnect()
+
+exports.getComponent = -> new Throttle()


### PR DESCRIPTION
This is a simple component that can be placed before another component that needs to be throttled lest the system run out of resources (memory, open files, etc). For example I use it with `ReadFile` as follows:

``` coffeescript
graph.addEdge "throttle", "out", "read file", "in"
graph.addEdge "read file", "load",  "throttle", "load"
```

This of course requires a modified `ReadFile` component that has a `load` out port. That is coming in a pending pull request.
