### PR TITLE
Forward key even when there is only one key

### DIFF
--- a/src/components/GetObjectKey.coffee
+++ b/src/components/GetObjectKey.coffee
@@ -47,9 +47,9 @@ class GetObjectKey extends noflo.Component
         throw "Data is not an object" unless typeof data is "object"
         for key in @key
             continue unless data[key]
-            @outPorts.out.beginGroup key unless @key.length is 1
+            @outPorts.out.beginGroup key
             @outPorts.out.send data[key]
-            @outPorts.out.endGroup() unless @key.length is 1
+            @outPorts.out.endGroup()
 
 exports.getComponent = ->
     new GetObjectKey


### PR DESCRIPTION
Even when there's only one key registered, the key should still be forwarded as a group because when the key was dynamically generated, the receiving component would have no idea what that key is.
