### PR TITLE
Forward disconnects

### DIFF
--- a/src/components/Group.coffee
+++ b/src/components/Group.coffee
@@ -18,4 +18,7 @@ class Group extends noflo.Component
     @inPorts.group.on 'data', (data) =>
       groups.push data
 
+    @inPorts.in.on "disconnect", () =>
+      @outPorts.out.disconnect()
+
 exports.getComponent = -> new Group


### PR DESCRIPTION
Curious if the Group component doesn't forward disconnects intentionally, but here's the one that does.
