### PR TITLE
Compile subgraphs into parent graphs before executing

### DIFF
--- a/src/lib/Fbp.coffee
+++ b/src/lib/Fbp.coffee
@@ -7,7 +7,7 @@ class Fbp
     matchInitial: new RegExp "\'(.+)\'"
     matchConnection: new RegExp "\-\>"
     matchSeparator: new RegExp "[\\s,\\n]"
-    matchSubgraph: new RegExp "\\'(.+)\\' *-> *GRAPH *([A-Za-z\\.]+)\\(Graph\\)"
+    matchSubgraph: new RegExp "\n *\\'(.+)\\' *-> *GRAPH *([A-Za-z\\.]+)\\(Graph\\)"
 
     constructor: ->
         @lastElement = null
@@ -41,12 +41,12 @@ class Fbp
                 fbp = fbp.replace(@matchComponentGlobal, "#{name}.$1($2)")
 
                 # Replace the graph statement with the FBP
-                string = string.replace(match, fbp)
+                string = string.replace(match, "\n#{fbp}")
 
 
     parse: (string) ->
         currentString = ""
-        string = @compileSubgraphs(string)
+        string = @compileSubgraphs("\n#{string}") # Pad string with newline in case the first line is a graph include
 
         for char, index in string
             @currentLine++ if char is "\n"


### PR DESCRIPTION
My other two outstanding pull requests (#40, #41) deal with subgraphs. They have always felt like unsafe patches to me, but I think I finally got a cleaner solution to it, but it does change the API so I really look forward to some input.

I figured that the problems that I've been encountering is due to the fact that subgraphs are initialized _after_ the parent graph is set up and ready to send IPs. This solution involves pre-compiling the sub-graphs directly into the parent graph (and do so recursively) before executing the graph.

So, in this completely trivial example:

```
# abc.fbp
'group' -> GROUP Group(Group)
Merge(Merge) OUT -> IN Group() OUT -> IN Split(Split)
```

```
# def.fbp
'abc.fbp' -> GRAPH A(Graph)
Merge(Merge) OUT -> IN A.Merge()
```

```
# main.fbp
'def.fbp' -> GRAPH A(Graph)
'initial' -> IN Merge(Merge) OUT -> IN A.Merge()
A.A.Split() OUT -> IN Output(Output)
```

This would yield (invisible to the programmer):

```
'group' -> GROUP A.A.Group(Group)
A.A.Merge(Merge) OUT -> IN A.A.Group() OUT -> IN A.A.Split(Split)

A.Merge(Merge) OUT -> IN A.A.Merge()

'initial' -> IN Merge(Merge) OUT -> IN A.Merge()
A.A.Split() OUT -> IN Output(Output)
```

What this does is eliminate all the testing and waiting for a ready-state. The namespace should also avoid any name clash since FBP doesn't have dots in component names.

The downside of this approach is the change at the API level.

Would this be a long-term solution to the problem?
