### PR TITLE
PR #55 Continued

### DIFF
--- a/src/lib/Fbp.coffee
+++ b/src/lib/Fbp.coffee
@@ -8,7 +8,7 @@ class Fbp
   matchInitial: new RegExp "\'(.+)\'"
   matchConnection: new RegExp "\-\>"
   matchSeparator: new RegExp "[\\s,\\n]"
-  matchSubgraph: new RegExp "\n *\\'(.+)\\' *-> *GRAPH *([A-Za-z\\.]+)\\(Graph\\)"
+  matchSubgraph: new RegExp "\n *\\'(.+)\\' *-> *GRAPH *([A-Za-z\\.]+)\\(Graph\\) *\n"
 
   constructor: ->
     @lastElement = null
@@ -25,7 +25,7 @@ class Fbp
       throw err if err
 
   # Compile subgraphs INTO the parent graph
-  compileSubgraphs: (string) ->
+  compileSubgraphs: (string, currentFile) ->
     loop
       match = string.match(@matchSubgraph)
 
@@ -36,14 +36,18 @@ class Fbp
       else
         [match, file, name, index, original] = match
 
+        # Cannot include self as a sub-graph
+        if file is currentFile
+          throw new Error("#{currentFile} is attempting to use itself as a sub-graph")
+
         # Get the FBP of the subgraph and compile that first
-        fbp = @compileSubgraphs(@loadFile(file))
+        fbp = @compileSubgraphs(@loadFile(file), file)
 
         # Affix the name to the beginning of all components in the subgraph
         fbp = fbp.replace(@matchComponentGlobal, "#{name}.$1($2)")
 
         # Replace the graph statement with the FBP
-        string = string.replace(match, "\n#{fbp}")
+        string = string.replace(match, "\n#{fbp}\n")
 
 
   parse: (string) ->


### PR DESCRIPTION
See #55

I'm back! This should work.
- Recursive inclusion of a subgraph would yield segmentation fault due to lack of termination case and so need to avoid.
- Subgraph needs to be on a stand-alone line to prevent (very) rare cases in which, say, you want that pattern of text inside an initializer.

However, I haven't included the test case because I realized that it's still four spaces. Do you want me to include it here?
- Finally add a test case to test/, which I wasn't aware before. :p
