### PR TITLE
Buffer all IPs and flush on disconnect

### DIFF
--- a/src/lib/ArrayPort.coffee
+++ b/src/lib/ArrayPort.coffee
@@ -1,73 +1,122 @@
 port = require "./Port"
+_ = require("underscore")
 
 class ArrayPort extends port.Port
   constructor: (name) ->
     @sockets = []
+    # Stack of grouping (i.e. where we currently are in the grouping hierarchy as IPs come in)
+    @stacks = {}
+    # The buffer of IPs
+    @bufferedData = {}
+    # A flag to prevent socket's emits duplicating existing buffers. Feels like a hack and it is because socket uses `emit`/`on` for both sending and receiving IPs (i.e. a duplex), so until someone discovers a smarter way, this is to stop listening while speaking.
+    @isSending = false
 
   attach: (socket) ->
     @sockets.push socket
-    @attachSocket socket, @sockets.length - 1
+    @attachSocket socket
 
-  connect: (socketId = null) ->
-    if socketId is null
-      @sockets.forEach (socket) ->
-        socket.connect()
-      return
+  attachSocket: (socket) ->
+    @emit "attach", socket
 
-    unless @sockets[socketId]
-      throw new Error "No socket '#{socketId}' available"
+    @from = socket.from
+    socket.setMaxListeners 0
+    socket.on "connect", (id) =>
+      @emit "connect", socket, id
+    socket.on "begingroup", (group, id) =>
+      @buffer("begingroup", group, @bufferedData[id], @stacks[id])
+      @emit "begingroup", group, id
+    socket.on "data", (data, id) =>
+      @buffer("data", data, @bufferedData[id], @stacks[id])
+      @emit "data", data, id
+    socket.on "endgroup", (group, id) =>
+      @buffer("endgroup", group, @bufferedData[id], @stacks[id])
+      @emit "endgroup", group, id
+    socket.on "disconnect", (id) =>
+      @emit "disconnect", socket, id
+      @clearBuffer(id)
 
-    @sockets[socketId].connect()
+  buffer: (type, value, buffer, stack) ->
+    return if @isSending
+    buffer ?= @bufferedData["__ALL__"] ?= {}
+    stack ?= @stacks["__ALL__"] ?= []
 
-  beginGroup: (group, socketId = null) ->
-    if socketId is null
-      @sockets.forEach (socket, index) =>
-        @beginGroup group, index
-      return
+    super(type, value, buffer, stack)
 
-    unless @sockets[socketId]
-      throw new Error "No socket '#{socketId}' available"
+  # Flush the buffered IPs
+  flush: (id) ->
+    socket = @sockets[id]
 
-    return @sockets[socketId].beginGroup group if @isConnected socketId
+    # Helper function to connect and flush
+    flushBuffer = (socket, id) =>
+      id ?= "__ALL__"
+      buffer = @bufferedData[id]
 
-    @sockets[socketId].once "connect", =>
-      @sockets[socketId].beginGroup group
-    @sockets[socketId].connect()
+      unless _.isEmpty(buffer)
+        socket.once "connect", =>
+          # Flush the buffer to output
+          @isSending = true
+          @flushBuffer(buffer, socket, id)
+          socket.disconnect(id)
+          @isSending = false
 
-  send: (data, socketId = null) ->
-    if socketId is null
-      @sockets.forEach (socket, index) =>
-        @send data, index
-      return
+        socket.connect(id)
 
-    unless @sockets[socketId]
-      throw new Error "No socket '#{socketId}' available"
+    # Socket-specific
+    if socket?
+      flushBuffer(socket, id)
 
-    return @sockets[socketId].send data if @isConnected socketId
+    # Buffer to be sent to all sockets
+    for socket, id in @sockets
+      buffer = @getBuffer()
+      flushBuffer(socket)
+      @setBuffer(buffer)
+    # Clear buffer only after all sockets have been sent the buffer
+    @clearBuffer()
 
-    @sockets[socketId].once "connect", =>
-      @sockets[socketId].send data
-    @sockets[socketId].connect()
+  # Recursive helper
+  flushBuffer: (buffer, socket, id) ->
+    for name, value of buffer
+      # Data
+      if name is "__DATA__"
+        for data in value
+          socket.send(data, id)
+      # Groups
+      else
+        socket.beginGroup(name, id)
+        @flushBuffer(value, socket, id)
+        socket.endGroup(name, id)
 
-  endGroup: (socketId = null) ->
-    if socketId is null
-      @sockets.forEach (socket, index) =>
-        @endGroup index
-      return
+  clearBuffer: (id) ->
+    id ?= "__ALL__"
+    @stacks[id] = []
+    @bufferedData[id] = {}
 
-    unless @sockets[socketId]
-      throw new Error "No socket '#{socketId}' available"
+  setup: (id) ->
+    throw new Error "No connection available" unless @isAttached(id)
+    # Designate flow to a certain id or to all
+    id ?= "__ALL__"
+    @stacks[id] ?= []
+    @bufferedData[id] ?= {}
+    id
 
-    do @sockets[socketId].endGroup
+  connect: () ->
+    @setup()
 
-  disconnect: (socketId = null) ->
-    if socketId is null
-      for socket in @sockets
-        socket.disconnect()
-      return
+  beginGroup: (group, id) ->
+    id = @setup(id)
+    @buffer("begingroup", group, @bufferedData[id], @stacks[id])
 
-    return unless @sockets[socketId]
-    @sockets[socketId].disconnect()
+  send: (data, id) ->
+    id = @setup(id)
+    @buffer("data", data, @bufferedData[id], @stacks[id])
+
+  endGroup: (id) ->
+    id = @setup(id)
+    @buffer("endgroup", null, @bufferedData[id], @stacks[id])
+
+  disconnect: (id) ->
+    return unless @isAttached(id)
+    @flush(id)
 
   detach: (socket) ->
     if @sockets.indexOf(socket) is -1
@@ -89,7 +138,51 @@ class ArrayPort extends port.Port
       return false
     @sockets[socketId].isConnected()
 
-  isAttached: ->
-    false
+  isAttached: (id) ->
+    if id?
+      @sockets[id]?
+    else
+      @sockets.length > 0
+
+  # Naive implementation of deep-copy. Only used to copy buffer when it is requested for external use. Use a library instead?
+  deepCopy: (obj) ->
+    copied = {}
+
+    for key, value of obj
+      if Object::toString.call(value) is "[object Object]"
+        copied[key] = @deepCopy(value)
+      else if Object::toString.call(value) is "[object Array]"
+        copied[key] = []
+        for item in value
+          copied[key].push(item)
+      else
+        copied[key] = value
+
+    copied
+
+  getData: (id) ->
+    id ?= "__ALL__"
+    super(@bufferedData[id], @stacks[id])
+  setData: (data, id) ->
+    id ?= "__ALL__"
+    super(data, @bufferedData[id], @stacks[id])
+
+  getGroups: (id) ->
+    id ?= "__ALL__"
+    @stacks[id] or []
+  setGroups: (groups, id) ->
+    id ?= "__ALL__"
+    @stacks[id] = groups
+
+  getBuffer: (id) ->
+    id ?= "__ALL__"
+    @deepCopy(@bufferedData[id])
+  setBuffer: (buffer, id) ->
+    id ?= "__ALL__"
+    @bufferedData[id] = buffer
+
+  getBufferData: (id) ->
+    id ?= "__ALL__"
+    super(@bufferedData[id])
 
 exports.ArrayPort = ArrayPort

--- a/src/lib/InternalSocket.coffee
+++ b/src/lib/InternalSocket.coffee
@@ -2,6 +2,7 @@
 #     (c) 2011 Henri Bergius, Nemein
 #     NoFlo may be freely distributed under the MIT license
 events = require "events"
+_ = require "underscore"
 
 # # Internal Sockets
 #
@@ -43,12 +44,17 @@ class InternalSocket extends events.EventEmitter
   connect: ->
     return if @connected
     @connected = true
-    @emit 'connect', @
+    @groups = []
+    emitArgs = ['connect']
+    Array::push.apply(emitArgs, arguments)
+    @emit.apply(@, emitArgs)
 
   disconnect: ->
     return unless @connected
     @connected = false
-    @emit 'disconnect', @
+    emitArgs = ['disconnect']
+    Array::push.apply(emitArgs, arguments)
+    @emit.apply(@, emitArgs)
 
   isConnected: -> @connected
 
@@ -65,7 +71,9 @@ class InternalSocket extends events.EventEmitter
   # message queues can be used as additional packet relay mechanisms.
   send: (data) ->
     @connect() unless @connected
-    @emit 'data', data
+    emitArgs = ['data']
+    Array::push.apply(emitArgs, arguments)
+    @emit.apply(@, emitArgs)
 
   # ## Information Packet grouping
   #
@@ -96,12 +104,18 @@ class InternalSocket extends events.EventEmitter
   # Components are free to ignore groupings, but are recommended
   # to pass received groupings onward if the data structures remain
   # intact through the component's processing.
-  beginGroup: (group) ->
-    @groups.push group
-    @emit 'begingroup', group
+  beginGroup: ->
+    emitArgs = ['begingroup']
+    group = _.toArray(arguments).shift()
+    @groups.push(group)
+    Array::push.apply(emitArgs, [group].concat(arguments))
+    @emit.apply(@, emitArgs)
 
   endGroup: ->
-    @emit 'endgroup', @groups.pop()
+    emitArgs = ['endgroup']
+    group = @groups.pop()
+    Array::push.apply(emitArgs, [group].concat(arguments))
+    @emit.apply(@, emitArgs)
 
   # ## Socket identifiers
   #

--- a/src/lib/Port.coffee
+++ b/src/lib/Port.coffee
@@ -5,110 +5,108 @@ class Port extends events.EventEmitter
     @name = name
     @socket = null
     @from = null
-    @downstreamIsGettingReady = false
-    @groups = []
-    @data = []
-    @buffer = []
-
-    @on "ready", () =>
-      if @downstreamIsGettingReady
-        # Reset the flag
-        @downstreamIsGettingReady = false
-
-        # Each record in buffer is a separate connection
-        for conn in @buffer
-          for group in conn.groups
-            @beginGroup(group)
-
-          for datum in conn.data
-            @send(datum)
-
-          for group in conn.groups
-            @endGroup()
-
-          @disconnect()
-
-        @buffer = []
+    # Stack of grouping (i.e. where we currently are in the grouping hierarchy as IPs come in)
+    @stack = []
+    # The buffer of IPs
+    @bufferedData = {}
+    # A flag to prevent socket's emits duplicating existing buffers. Feels like a hack and it is because socket uses `emit`/`on` for both sending and receiving IPs (i.e. a duplex), so until someone discovers a smarter way, this is to stop listening while speaking.
+    @isSending = false
 
   attach: (socket) ->
-    throw new Error "#{@name}: Socket already attached #{@socket.getId()} - #{socket.getId()}" if @isAttached()
+    throw new Error "#{@name}: Socket already attached #{@socket.getId()} - #{socket.getId()}" if @socket
     @socket = socket
 
     @attachSocket socket
 
-  attachSocket: (socket, localId = null) ->
+  attachSocket: (socket) ->
     @emit "attach", socket
 
     @from = socket.from
     socket.setMaxListeners 0
     socket.on "connect", =>
-      @emit "connect", socket, localId
+      @emit "connect", socket
     socket.on "begingroup", (group) =>
-      @emit "begingroup", group, localId
+      @buffer("begingroup", group)
+      @emit "begingroup", group
     socket.on "data", (data) =>
-      @emit "data", data, localId
+      @buffer("data", data)
+      @emit "data", data
     socket.on "endgroup", (group) =>
-      @emit "endgroup", group, localId
+      @buffer("endgroup", group)
+      @emit "endgroup", group
     socket.on "disconnect", =>
-      @emit "disconnect", socket, localId
+      @emit "disconnect", socket
+      @clearBuffer()
+
+  # Buffer IPs and flush on disconnect
+  buffer: (type, value, buffer, stack) ->
+    return if @isSending
+    buffer ?= @bufferedData
+    stack ?= @stack
+
+    # Get to where we are right now in buffer
+    for step in stack
+      buffer = buffer[step]
+
+    switch type
+      when "begingroup"
+        buffer[value] ?= {}
+        stack.push(value)
+      when "data"
+        buffer["__DATA__"] ?= []
+        buffer["__DATA__"].push(value)
+      when "endgroup"
+        stack.pop()
+
+  # Flush the buffered IPs
+  flush: () ->
+    @socket.once "connect", =>
+      @isSending = true
+      @flushBuffer(@bufferedData, @socket)
+      @socket.disconnect()
+      @isSending = false
+
+    @socket.connect()
+
+  # Recursive helper
+  flushBuffer: (buffer, socket) ->
+    for name, value of buffer
+      # Data
+      if name is "__DATA__"
+        for data in value
+          socket.send(data)
+      # Groups
+      else
+        socket.beginGroup(name)
+        @flushBuffer(value, socket)
+        socket.endGroup(name)
+
+  # Each connection should clear buffer before use
+  clearBuffer: () ->
+    @stack = []
+    @bufferedData = {}
 
   connect: ->
-    if @downstreamIsGettingReady
-      return
-
-    throw new Error "No connection available" unless @socket
-    do @socket.connect
+    throw new Error "No connection available" unless @isAttached()
+    @clearBuffer()
 
   beginGroup: (group) ->
-    if @downstreamIsGettingReady
-      @groups.push(group)
-      return
-
-    throw new Error "No connection available" unless @socket
-
-    return @socket.beginGroup group if @isConnected()
-
-    @socket.once "connect", =>
-      @socket.beginGroup group
-    do @socket.connect
+    throw new Error "No connection available" unless @isAttached()
+    @buffer("begingroup", group)
 
   send: (data) ->
-    if @downstreamIsGettingReady
-      @data.push(data)
-      return
-
-    throw new Error "No connection available" unless @socket
-
-    return @socket.send data if @isConnected()
-
-    @socket.once "connect", =>
-      @socket.send data
-    do @socket.connect
+    throw new Error "No connection available" unless @isAttached()
+    @buffer("data", data)
 
   endGroup: ->
-    if @downstreamIsGettingReady
-      return
-
-    throw new Error "No connection available" unless @socket
-    do @socket.endGroup
+    throw new Error "No connection available" unless @isAttached()
+    @buffer("endgroup")
 
   disconnect: ->
-    if @downstreamIsGettingReady
-      buffer =
-        groups: @groups
-        data: @data
-      @buffer.push(buffer)
-
-      @groups = []
-      @data = []
-
-      return
-
-    return unless @socket
-    @socket.disconnect()
+    return unless @isAttached()
+    @flush()
 
   detach: (socket) ->
-    return unless @isAttached socket
     @emit "detach", @socket
     @from = null
     @socket = null
@@ -120,5 +118,51 @@ class Port extends events.EventEmitter
 
   isAttached: ->
     @socket isnt null
+
+  # Get to the data IPs given a "group path" in the buffered IPs' hierarchy. Using array methods on it will directly change the buffer.
+  getData: (buffer, stack) ->
+    buffer ?= @bufferedData
+    stack ?= @stack
+
+    for step in stack
+      buffer = buffer[step]
+
+    buffer["__DATA__"] ?= []
+
+  setData: (data, buffer, stack) ->
+    buffer ?= @bufferedData
+    stack ?= @stack
+
+    for step in stack
+      buffer = buffer[step]
+
+    buffer["__DATA__"] = data
+
+  # Get the "path" of groups at this point in time. Say groups "A", "B", and "C" were begun but not ended, you'd get `["A", "B", "C"]`. Good for hierarchical grouping.
+  getGroups: ->
+    @stack
+  setGroups: (@stack) ->
+
+  # Get the entire `bufferedData` object
+  getBuffer: ->
+    @bufferedData
+  setBuffer: (@bufferedData) ->
+
+  # Get only the data IPs
+  getBufferData: (buffer) ->
+    buffer ?= @bufferedData
+
+    traverse = (buffer) ->
+      ret = []
+
+      for key, value of buffer
+        if key is "__DATA__"
+          ret.push(value)
+        else
+          ret.push.apply(ret, traverse(value))
+
+      ret
+  
+    traverse(buffer)
 
 exports.Port = Port


### PR DESCRIPTION
Phew. This is a big PR. So here we go:

This may be familiar to you:

```
class SomeComponent ...
...
@inPorts.in.on "beginGroup", (group) ->
  @groups.push(group)
@inPorts.in.on "data", (data) ->
   # Do something here
@inPorts.in.on "endGroup", (group) ->
  @groups.pop()
@inPorts.in.on "disconnect", () ->
   # Do some more things here
...
```

This is quite common in the existing libraries and I find myself doing this over and over again. Not only that, when I need to manipulate the data in batch, like examining the groups and deciding to send the data forward or not, I need to do something like this:

```
class SomeComponent ...
...
@inPorts.in.on "beginGroup", (group) ->
  @groups.push(group)
@inPorts.in.on "data", (data) ->
   @data.push(data)
@inPorts.in.on "endGroup", (group) ->
  @groups.pop()
@inPorts.in.on "disconnect", () ->
  # Do some tests/filters/manipulation/whatever here
  for group in @groups
    @outPorts.out.beginGroup(group)
  for datum in @data
    @outPorts.out.send(datum)
  for group in @groups
    @outPorts.out.endGroup()
  @outPorts.out.disconnect()
...
```

Doing either the first example or the second example repeatedly is not fun, nor is it correct: you lose the structure of groupings. Instead of having something like an XML-like tree structure, which groups are supposed to provide, by the time you access it, it's linear.

Hence this PR. It expands the role of the port to allow _each_ port to have a buffer of incoming/outgoing connection. It flushes itself every time a connection is disconnected. The primary benefit is that until you disconnect, you know that you still have the data at bay and you can manipulate it. So for example:

```
class SomeComponent ...
...
@inPorts.in.on "beginGroup", (group) ->
  @outPorts.out.beginGroup(group)
@inPorts.in.on "data", (data) ->
  groups = @outPorts.out.getGroups()
  # Only grouped data are forwarded
  if groups.length > 0
    @outPorts.out.send(data)
@inPorts.in.on "endGroup", (group) ->
    @outPorts.out.endGroup()
@inPorts.in.on "disconnect", () ->
  buffer = @outPorts.out.getBuffer()
  # Do something with the buffer
  @outPorts.out.setBuffer(buffer)
  @outPorts.out.disconnect()
...
```

This is a trivial example but you can see that I can choose to manipulate all the "sent" groups/data _before_ they actually get sent. Great for batch operations.

Here are the side benefits:
1. Now a downstream process would not be aware that an IP is coming its way _until_ the connection between its upstream processes disconnect. This is a problem right now because it forwards groups/data immediately so in a synchronous graph, all processes would receive a `beginGroup` before they get a `data`. This is not how the mental model of FBP should work (at least not mine :p)
2. There is no initial downstream connection problem. See #40.
3. You force the programmer to write correct FBP programs. I mean, you _have_ to disconnect for your stuff to be sent.

Now this was done a while back. I have been testing it in production so it was before the style change and me knowing that there was a test directory. I will throw in tests for this but I need to know if this is something from which noflo can benefit. I imagined it could be a separate `class BufferedPort extends Port` but I think it's not necessary because it's backward-compatible.

Let me know if I can clarify any aspect of this since this is a pretty big change in the codebase.
