### PR TITLE
Update grunt-cafe-mocha to updated version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "grunt-bumpup": "~0.2.0",
     "grunt-tagrelease": "~0.2.0",
     "grunt-exec": "~0.4.0",
-    "grunt-cafe-mocha": "~0.1.1",
+    "grunt-cafe-mocha": "~0.1.2",
     "chai": "~1.5.0",
     "mocha": "~1.9.0",
     "grunt-mocha-phantomjs": "~0.2.0",


### PR DESCRIPTION
Version 0.1.2 should fix the issues that you were having. It now uses the builtin Grunt failure messages to warn about a failure and return the appropriate status code, which should let CI systems like Travis, Jenkins respond appropriately.

Let me know if you have any other issues!

Thanks!
