### PR TITLE
Preserve order of initial packets

### DIFF
--- a/src/lib/Network.coffee
+++ b/src/lib/Network.coffee
@@ -158,16 +158,19 @@ class Network extends EventEmitter
     # it
     serialize = (next, add) =>
       (type) =>
-        # Add either Initial or Edge and move on to the next one when done
+        # Add either a Node, an Initial, or an Edge and move on to the next one
+        # when done
         this["add#{type}"] add, ->
           next type
 
     # Serialize initializers then call callback when done
     initializers = _.reduceRight @graph.initializers, serialize, done
-    # Serialize edge creators then call initializers
+    # Serialize edge creators then call the initializers
     edges = _.reduceRight @graph.edges, serialize, -> initializers "Initial"
-    # Start with edges
-    edges "Edge"
+    # Serialize node creators then call the edge creators
+    nodes = _.reduceRight @graph.nodes, serialize, -> edges "Edge"
+    # Start with node creators
+    nodes "Node"
 
   connectPort: (socket, process, port, inbound) ->
     if inbound

--- a/src/lib/NoFlo.coffee
+++ b/src/lib/NoFlo.coffee
@@ -9,7 +9,6 @@ arrayport = require "./ArrayPort"
 graph = require "./Graph"
 {Network} = require "./Network"
 {LoggingComponent} = require "./LoggingComponent"
-_ = require "underscore"
 
 if typeof process is 'object' and process.title is 'node'
   componentLoader = require "./nodejs/ComponentLoader"
@@ -20,11 +19,10 @@ exports.createNetwork = (graph, callback) ->
   network = new Network graph
 
   networkReady = (network) ->
-    callback network if _.isFunction callback
+    callback network if callback?
     network.sendInitials()
 
-  toAddNodes = graph.nodes.length
-  if toAddNodes is 0
+  if graph.nodes.length is 0
     setTimeout ->
       networkReady network
     , 0
@@ -32,12 +30,8 @@ exports.createNetwork = (graph, callback) ->
 
   # Ensure components are loaded before continuing
   network.loader.listComponents ->
-    for node in graph.nodes
-      network.addNode node, ->
-        toAddNodes--
-        if toAddNodes is 0
-          network.connect ->
-            networkReady network
+    network.connect ->
+      networkReady network
 
   network
 


### PR DESCRIPTION
Continuing from #73. You should've waited. :p 

Upon looking into it, I agree with you that that segment of code should be in Network rather than NoFlo. In fact, refactoring the Node and Edge connections into the serialization was a bliss. Now it's even more lean. Love how you saw that. Let me know if this is what you wanted.
