### PR TITLE
Avoid loading custom packages' names

### DIFF
--- a/src/lib/nodejs/ComponentLoader.coffee
+++ b/src/lib/nodejs/ComponentLoader.coffee
@@ -29,6 +29,7 @@ class ComponentLoader extends loader.ComponentLoader
 
     # Handle sub-modules
     _.each moduleDef.dependencies, (def) =>
+      return done() unless def.name?
       return done() unless @checked.indexOf(def.name) is -1
       @getModuleComponents def, (depComponents) ->
         return done() if _.isEmpty depComponents


### PR DESCRIPTION
I don't know whether this is a problem for anyone or what causes this. When I'm extensively linking various noflo packages locally for development, noflo would fetch a "null" dependency so that the sub-modules callback would receive a `null` for `def`, rendering an error. This issue only happens when packages are linked using `npm link`.
