### PR TITLE
Add all detected components but not those already added

### DIFF
--- a/src/lib/nodejs/ComponentLoader.coffee
+++ b/src/lib/nodejs/ComponentLoader.coffee
@@ -21,7 +21,6 @@ log.pause()
 class ComponentLoader extends loader.ComponentLoader
   getModuleComponents: (moduleDef, callback) ->
     components = {}
-    @checked.push moduleDef.name
 
     depCount = _.keys(moduleDef.dependencies).length
     done = _.after depCount + 1, =>
@@ -30,10 +29,10 @@ class ComponentLoader extends loader.ComponentLoader
     # Handle sub-modules
     _.each moduleDef.dependencies, (def) =>
       return done() unless def.name?
-      return done() unless @checked.indexOf(def.name) is -1
       @getModuleComponents def, (depComponents) ->
         return done() if _.isEmpty depComponents
-        components[name] = cPath for name, cPath of depComponents
+        # Add component only if it hasn't been added before
+        components[name] ?= cPath for name, cPath of depComponents
         done()
 
     # No need for further processing for non-NoFlo projects


### PR DESCRIPTION
NoFlo currently ignores entire packages of the same name that have already been added. This creates a problem as the graph's number of dependencies increases as there's bound to be some packages using newer versions of the same package than others. Right now it imports the first one as returned by `read-installed` so an older package may shadow a newer version of itself. This patch avoids conflicts at the component-level rather than the package-level.
