### PR TITLE
ArrayPort: change isAttached() to return true with no argument if at least one socket

### DIFF
--- a/src/lib/ArrayPort.coffee
+++ b/src/lib/ArrayPort.coffee
@@ -106,7 +106,9 @@ class ArrayPort extends port.Port
     @sockets[socketId].isConnected()
 
   isAttached: (socketId) ->
-    return false if socketId is undefined
+    if socketId is undefined
+      return true if @sockets.length > 0
+      return false
     return true if @sockets[socketId]
     false
 


### PR DESCRIPTION
The current implementation of isAttached() for ArrayPort could return true in the case it's been called with no argument, if there is at least one socket attached to the port.
