### PR TITLE
Network: send number when sending initials if port's type is number

### DIFF
--- a/src/lib/Network.coffee
+++ b/src/lib/Network.coffee
@@ -362,8 +362,12 @@ class Network extends EventEmitter
       @connections.splice @connections.indexOf(connection), 1
 
   sendInitial: (initial) ->
+    portType = initial.socket.to.process.component.inPorts[initial.socket.to.port].type
     initial.socket.connect()
-    initial.socket.send initial.data
+    if portType == 'number'
+      initial.socket.send parseInt(initial.data)
+    else
+      initial.socket.send initial.data
     initial.socket.disconnect()
 
   sendInitials: ->


### PR DESCRIPTION
If you put a number in a fbp graph description and the port this number is sent to expects is an argument of type 'number', this port will receive a string argument.
No sure whether this should be fixed in NoFlo or Fbp...
