### PR TITLE
fix subgraph loading on windows

### DIFF
--- a/src/components/Graph.coffee
+++ b/src/components/Graph.coffee
@@ -40,7 +40,7 @@ class Graph extends noflo.Component
         @createNetwork instance
       return
 
-    if graph.substr(0, 1) isnt "/"
+    if graph.substr(0, 1) isnt "/" and graph.substr(1, 1) isnt ":"
       graph = "#{process.cwd()}/#{graph}"
 
     graph = noflo.graph.loadFile graph, (instance) =>


### PR DESCRIPTION
Using a subgraph in a graph is currently not working in windows.

![image](https://f.cloud.github.com/assets/596578/1819679/ee1fc4ba-70a9-11e3-8ea0-e27aa81cb0cf.png)

This quick fix checks for the colon to recognize C:, D:, ...
