### PR TITLE
Ports: make on() method available on InPorts and OutPorts

### DIFF
--- a/src/lib/Ports.coffee
+++ b/src/lib/Ports.coffee
@@ -41,10 +41,11 @@ class Ports extends EventEmitter
     delete @[name]
     @emit 'remove', name
 
-exports.InPorts = class InPorts extends Ports
   on: (name, event, callback) ->
     throw new Error "Port #{name} not available" unless @ports[name]
     @ports[name].on event, callback
+
+exports.InPorts = class InPorts extends Ports
   once: (name, event, callback) ->
     throw new Error "Port #{name} not available" unless @ports[name]
     @ports[name].once event, callback


### PR DESCRIPTION
Components might want to be able to listen on 'attach' events etc... from their output ports like they do on there input ports.
