### PR TITLE
Updated eval version in package.json from ^ to ~.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "npmlog": "0.0.x",
     "coffee-script": ">=1.1.0",
     "fbp": "1.1.x",
-    "eval": "^0.1.0"
+    "eval": "~0.1.0"
   },
   "devDependencies": {
     "grunt": "~0.4.1",


### PR DESCRIPTION
When I attempted to update my component [noflo-forecastio](https://github.com/KevinHoward/noflo-forecastio) to use NoFlo 0.5.x, Travis CI errors with the following message:

```
npm ERR! Error: No compatible version found: eval@'^0.1.0'
npm ERR! Valid install targets:
npm ERR! ["0.0.1","0.0.2","0.0.3","0.0.4","0.1.0"]
npm ERR!     at installTargetsError (/home/travis/.nvm/v0.8.26/lib/node_modules/npm/lib/cache.js:719:10)
npm ERR!     at /home/travis/.nvm/v0.8.26/lib/node_modules/npm/lib/cache.js:641:10
npm ERR!     at saved (/home/travis/.nvm/v0.8.26/lib/node_modules/npm/node_modules/npm-registry-client/lib/get.js:138:7)
npm ERR!     at Object.oncomplete (fs.js:297:15)
npm ERR! If you need help, you may report this log at:
npm ERR!     <http://github.com/isaacs/npm/issues>
npm ERR! or email it to:
npm ERR!     <npm-@googlegroups.com>
```

[https://travis-ci.org/KevinHoward/noflo-forecastio/builds/22471394](https://travis-ci.org/KevinHoward/noflo-forecastio/builds/22471394)
