### PR TITLE
guess component source language using filename extension

### DIFF
--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -6,11 +6,13 @@ if typeof process isnt 'undefined' and process.execPath and process.execPath.ind
   platform = require '../src/lib/Platform.coffee'
   path = require 'path'
   root = path.resolve __dirname, '../'
+  shippingLanguage = 'coffeescript'
 else
   loader = require 'noflo/src/lib/ComponentLoader.js'
   component = require 'noflo/src/lib/Component.js'
   platform = require 'noflo/src/lib/Platform.js'
   root = 'noflo'
+  shippingLanguage = 'javascript'
 
 describe 'ComponentLoader with no external packages installed', ->
   l = new loader.ComponentLoader root
@@ -126,6 +128,7 @@ describe 'ComponentLoader with no external packages installed', ->
         chai.expect(component.code.indexOf('exports.getComponent')).to.not.equal -1
         chai.expect(component.name).to.equal 'Graph'
         chai.expect(component.library).to.equal ''
+        chai.expect(component.language).to.equal shippingLanguage
         done()
     it 'should return an error for missing components', (done) ->
       l.getSource 'foo/BarBaz', (err, src) ->

--- a/src/lib/ComponentLoader.coffee
+++ b/src/lib/ComponentLoader.coffee
@@ -6,6 +6,7 @@
 # This is the browser version of the ComponentLoader.
 internalSocket = require './InternalSocket'
 nofloGraph = require './Graph'
+utils = require './Utils'
 unless require('./Platform').isBrowser()
   {EventEmitter} = require 'events'
 else
@@ -251,6 +252,7 @@ class ComponentLoader extends EventEmitter
       name: nameParts[1]
       library: nameParts[0]
       code: window.require.modules[path].toString()
+      language: utils.guessLanguageFromFilename component
 
   clear: ->
     @components = null

--- a/src/lib/Utils.coffee
+++ b/src/lib/Utils.coffee
@@ -25,4 +25,10 @@ clone = (obj) ->
 
   return newInstance
 
+# Guess language from filename
+guessLanguageFromFilename = (filename) ->
+  return 'coffeescript' if /.*\.coffee$/.test filename
+  return 'javascript'
+
 exports.clone = clone
+exports.guessLanguageFromFilename = guessLanguageFromFilename

--- a/src/lib/nodejs/ComponentLoader.coffee
+++ b/src/lib/nodejs/ComponentLoader.coffee
@@ -11,12 +11,12 @@ path = require 'path'
 fs = require 'fs'
 loader = require '../ComponentLoader'
 internalSocket = require '../InternalSocket'
+utils = require '../Utils'
 
 # We allow components to be un-compiled CoffeeScript
 CoffeeScript = require 'coffee-script'
 if typeof CoffeeScript.register != 'undefined'
     CoffeeScript.register()
-
 
 # Disable NPM logging in normal NoFlo operation
 log = require 'npmlog'
@@ -179,6 +179,7 @@ class ComponentLoader extends loader.ComponentLoader
       callback null,
         name: nameParts[1]
         library: nameParts[0]
+        language: utils.guessLanguageFromFilename component
         code: code
 
   readPackage: (packageId, callback) ->


### PR DESCRIPTION
The runtime protocol specification (http://noflojs.org/documentation/protocol/) states that a runtime should provide the language associated with its components and this isn't optional.
Here is an implementation of guess of the language based on file extension.
