### PR TITLE
BasePort: add 'function' to the list of valid data types

### DIFF
--- a/src/lib/BasePort.coffee
+++ b/src/lib/BasePort.coffee
@@ -19,6 +19,7 @@ validTypes = [
   'color'
   'date'
   'bang'
+  'function'
 ]
 
 class BasePort extends EventEmitter


### PR DESCRIPTION
The 'function' type is used by noflo-core components like : 
https://github.com/noflo/noflo-core/blob/master/components/Callback.coffee#L17
https://github.com/noflo/noflo-core/blob/master/components/MakeFunction.coffee#L21
