### PR TITLE
Make port names uppercase in CLI output.

### DIFF
--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -46,6 +46,15 @@ describe 'ComponentLoader with no external packages installed', ->
     it 'should have the Graph component registered', ->
       chai.expect(l.components.Graph).not.to.be.empty
 
+  it 'should list components with uppercase port names for display', (done) ->
+    l.listComponentsForDisplay (components) ->
+      displayNames = (key for key of components)
+      componentNames = (key for key of l.components)
+      chai.expect(displayNames.length).to.equal componentNames.length
+      for name, index in componentNames
+        chai.expect(name.toUpperCase()).to.equal displayNames[index]
+      done()
+
   describe 'loading the Graph component', ->
     instance = null
     it 'should be able to load the component', (done) ->

--- a/src/bin/noflo.coffee
+++ b/src/bin/noflo.coffee
@@ -71,7 +71,7 @@ cli.main (args, options) ->
   if cli.args.length is 2 and cli.args[0] is 'list'
     baseDir = path.resolve process.cwd(), cli.args[1]
     loader = new noflo.ComponentLoader baseDir
-    loader.listComponents (components) ->
+    loader.listComponentsForDisplay (components) ->
       todo = components.length
       _.each components, (path, component) ->
         instance = loader.load component, (instance) ->

--- a/src/lib/ComponentLoader.coffee
+++ b/src/lib/ComponentLoader.coffee
@@ -83,6 +83,11 @@ class ComponentLoader extends EventEmitter
       callback @components if callback
     , 1
 
+  listComponentsForDisplay: (callback) ->
+    components = {}
+    components[key.toUpperCase()] = value for key, value of @components
+    callback components
+
   load: (name, callback, delayed, metadata) ->
     unless @ready
       @listComponents =>


### PR DESCRIPTION
Fixes #100. I could add a test for this but it would require some refactoring of `showComponent`.
