### PR TITLE
GroupComponent helper.

### DIFF
--- a/spec/Helpers.coffee
+++ b/spec/Helpers.coffee
@@ -67,3 +67,126 @@ describe 'Component traits', ->
       s.endGroup()
       s.endGroup()
       s.disconnect()
+
+  describe 'GroupComponent', ->
+    c = new component.Component
+    c.inPorts.add 'x',
+      required: true
+      datatype: 'int'
+    c.inPorts.add 'y',
+      required: true
+      datatype: 'int'
+    c.inPorts.add 'z',
+      required: true
+      datatype: 'int'
+    c.outPorts.add 'point'
+    x = new socket.createSocket()
+    y = new socket.createSocket()
+    z = new socket.createSocket()
+    p = new socket.createSocket()
+    c.inPorts.x.attach x
+    c.inPorts.y.attach y
+    c.inPorts.z.attach z
+    c.outPorts.point.attach p
+    it 'should pass data and groups to the callback', (done) ->
+      src =
+        111: {x: 1, y: 2, z: 3}
+        222: {x: 4, y: 5, z: 6}
+        333: {x: 7, y: 8, z: 9}
+      helpers.GroupComponent c, (data, groups, out) ->
+        chai.expect(data).to.deep.equal src[groups[0]]
+        out.send data
+        # done() if groups[0] is 333
+      , ['x', 'y', 'z'], 'point'
+
+      groups = []
+      count = 0
+      p.on 'begingroup', (grp) ->
+        groups.push grp
+      p.on 'endgroup', ->
+        groups.pop()
+      p.on 'data', (data) ->
+        count++
+      p.on 'disconnect', ->
+        done() if count is 3 and groups.length is 0
+
+      for key, grp of src
+        x.beginGroup key
+        y.beginGroup key
+        z.beginGroup key
+        x.send grp.x
+        y.send grp.y
+        z.send grp.z
+        x.endGroup()
+        y.endGroup()
+        z.endGroup()
+        x.disconnect()
+        y.disconnect()
+        z.disconnect()
+
+    it 'should work without a group provided', (done) ->
+      p.removeAllListeners()
+      helpers.GroupComponent c, (data, groups, out) ->
+        chai.expect(groups.length).to.equal 0
+        out.send {x: data.x, y: data.y, z: data.z}
+      , ['x', 'y', 'z'], 'point'
+
+      p.once 'data', (data) ->
+        chai.expect(data).to.deep.equal {x: 123, y: 456, z: 789}
+        done()
+
+      x.send 123
+      x.disconnect()
+      y.send 456
+      y.disconnect()
+      z.send 789
+      z.disconnect()
+
+    it 'should process inputs for different groups independently', (done) ->
+      src =
+        1: {x: 1, y: 2, z: 3}
+        2: {x: 4, y: 5, z: 6}
+        3: {x: 7, y: 8, z: 9}
+      inOrder = [
+        [ 1, 'x' ]
+        [ 3, 'z' ]
+        [ 2, 'y' ]
+        [ 2, 'x' ]
+        [ 1, 'z' ]
+        [ 2, 'z' ]
+        [ 3, 'x' ]
+        [ 1, 'y' ]
+        [ 3, 'y' ]
+      ]
+      outOrder = [ 2, 1, 3 ]
+
+      helpers.GroupComponent c, (data, groups, out) ->
+        out.send {x: data.x, y: data.y, z: data.z}
+      , ['x', 'y', 'z'], 'point'
+
+      groups = []
+
+      p.on 'begingroup', (grp) ->
+        groups.push grp
+      p.on 'endgroup', (grp) ->
+        groups.pop()
+      p.on 'data', (data) ->
+        chai.expect(groups.length).to.equal 1
+        chai.expect(groups[0]).to.equal outOrder[0]
+        chai.expect(data).to.deep.equal src[outOrder[0]]
+        outOrder.shift()
+        done() unless outOrder.length
+
+      for tuple in inOrder
+        input = null
+        switch tuple[1]
+          when 'x'
+            input = x
+          when 'y'
+            input = y
+          when 'z'
+            input = z
+        input.beginGroup tuple[0]
+        input.send src[tuple[0]][tuple[1]]
+        input.endGroup()
+        input.disconnect()

--- a/src/lib/Helpers.coffee
+++ b/src/lib/Helpers.coffee
@@ -24,3 +24,39 @@ exports.MapComponent = (component, func, config) ->
       when 'disconnect'
         groups = []
         outPort.disconnect()
+
+exports.GroupComponent = (component, func, inPorts='in', outPort='out', config={}) ->
+  unless Object.prototype.toString.call(inPorts) is '[object Array]'
+    inPorts = [inPorts]
+
+  for name in inPorts
+    unless component.inPorts[name]
+      throw new Error "no inPort named '#{name}'"
+  unless component.outPorts[outPort]
+    throw new Error "no outPort named '#{outPort}'"
+
+  groupedData = {}
+
+  out = component.outPorts[outPort]
+
+  for port in inPorts
+    do (port) ->
+      inPort = component.inPorts[port]
+      inPort.groups = []
+      inPort.process = (event, payload) ->
+        switch event
+          when 'begingroup'
+            inPort.groups.push payload
+          when 'data'
+            key = inPort.groups.toString()
+            groupedData[key] = {} unless key of groupedData
+            groupedData[key][port] = payload
+            # Flush the data if the tuple is complete
+            if Object.keys(groupedData[key]).length is inPorts.length
+              out.beginGroup group for group in inPort.groups
+              func groupedData[key], inPort.groups, out
+              out.endGroup() for group in inPort.groups
+              out.disconnect()
+              delete groupedData[key]
+          when 'endgroup'
+            inPort.groups.pop()


### PR DESCRIPTION
`GroupComponent` helper implements a sync component that collects input from a set of inports and passes the collected tuple to a callback along with the groups and the main outport that it can use to send output. If group information is provided on inports, then input data from matching groups is combined and group information is automatically forwarded to the output along with the callback's response.

Refs https://github.com/noflo/noflo/issues/166
