### PR TITLE
WirePattern fixes

### DIFF
--- a/spec/Helpers.coffee
+++ b/spec/Helpers.coffee
@@ -753,6 +753,7 @@ describe 'Component traits', ->
         d1.disconnect()
         d2.send 123
         d2.disconnect()
+        c.sendDefaults()
         p1.send 'req'
         p1.disconnect()
         # the handler should be triggered here
@@ -801,6 +802,7 @@ describe 'Component traits', ->
         d1.disconnect()
         d2.send 123
         d2.disconnect()
+        c.sendDefaults()
         p1.send 'req'
         p1.disconnect()
         # the handler should be triggered here
@@ -916,6 +918,7 @@ describe 'Component traits', ->
             chai.expect(c.invCount).to.equal 3
             done()
 
+        c.sendDefaults()
         line.send 'op'
         rpt.send 10
         line.disconnect()

--- a/src/lib/Helpers.coffee
+++ b/src/lib/Helpers.coffee
@@ -185,7 +185,7 @@ exports.WirePattern = (component, config, proc) ->
   component.defaultedParams = []
   component.defaultsSent = false
 
-  sendDefaultParams = ->
+  component.sendDefaults = ->
     if component.defaultedParams.length > 0
       for param in component.defaultedParams
         if component.receivedParams.indexOf(param) is -1
@@ -364,9 +364,6 @@ exports.WirePattern = (component, config, proc) ->
             # Before hook
             if typeof component.beforeProcess is 'function'
               component.beforeProcess outs
-
-            # Sending defaults if not sent already
-            sendDefaultParams() unless component.defaultsSent
 
             # Group forwarding
             if outPorts.length is 1


### PR DESCRIPTION
- Fixed a bug in disconnect forwarding.
- Async components are `ordered: true` by default.
- Fixed #225 and added `component.sendDefaults()` when using WirePattern.
