### PR TITLE
BasePort: fix isConnected() when no socket are attached

### DIFF
--- a/src/lib/BasePort.coffee
+++ b/src/lib/BasePort.coffee
@@ -105,6 +105,7 @@ class BasePort extends EventEmitter
 
     connected = false
     @sockets.forEach (socket) =>
+      return unless socket
       if socket.isConnected()
         connected = true
     return connected


### PR DESCRIPTION
Spotted exception with WirePattern when no output port is connected.
Sounds like we should do the same as listAttached() in isConnected() or do a isAttached() first thing as we enter isConnected().
