### PR TITLE
Fixed a bug in WirePattern output queue

### DIFF
--- a/src/lib/Helpers.coffee
+++ b/src/lib/Helpers.coffee
@@ -164,7 +164,8 @@ exports.WirePattern = (component, config, proc) ->
           streams = tmp
         for key, stream of streams
           if stream.resolved
-            flushed = flushed or stream.flush()
+            stream.flush()
+            flushed = true
       component.outputQ.shift() if flushed
       return unless flushed
 


### PR DESCRIPTION
The bug didn't let it wipe unflushed streams out if a component didn't send data because of an error.
