### PR TITLE
ComponentLoader: Load components on-demand in setSource also on node.js

### DIFF
--- a/src/lib/nodejs/ComponentLoader.coffee
+++ b/src/lib/nodejs/ComponentLoader.coffee
@@ -133,6 +133,11 @@ class ComponentLoader extends loader.ComponentLoader
       return callback null, found
 
   setSource: (packageId, name, source, language, callback) ->
+    unless @ready
+      @listComponents =>
+        @setSource packageId, name, source, language, callback
+      return
+
     _eval = require 'eval'
     if language is 'coffeescript'
       try


### PR DESCRIPTION
Caused exception due to this.components being null when Flowhub
sent component:setsource message before the first component:component
message. Was already handled for noflo-browser
