### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,7 @@
   ],
   "author": "Henri Bergius <henri.bergius@iki.fi>",
   "version": "0.5.13",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/noflo/noflo/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "engines": {
     "node": ">=0.6.0"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/