### PR TITLE
babel support for the node component loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,16 @@
     "node": ">=0.6.0"
   },
   "dependencies": {
-    "shell": "0.2.x",
+    "babel-core": "^5.8.23",
     "cli": ">=0.3.7",
     "cli-color": ">=0.2.1",
-    "underscore": ">=1.3.3",
-    "read-installed": "2.0.7",
-    "npmlog": "0.0.x",
     "coffee-script": ">=1.1.0",
+    "eval": "^0.1.0",
     "fbp": "1.1.x",
-    "eval": "^0.1.0"
+    "npmlog": "0.0.x",
+    "read-installed": "2.0.7",
+    "shell": "0.2.x",
+    "underscore": ">=1.3.3"
   },
   "devDependencies": {
     "chai": "~1.9.0",

--- a/src/lib/nodejs/ComponentLoader.coffee
+++ b/src/lib/nodejs/ComponentLoader.coffee
@@ -18,6 +18,7 @@ nofloGraph = require '../Graph'
 CoffeeScript = require 'coffee-script'
 if typeof CoffeeScript.register != 'undefined'
     CoffeeScript.register()
+babel = require 'babel-core'
 
 # Disable NPM logging in normal NoFlo operation
 log = require 'npmlog'
@@ -201,6 +202,11 @@ class ComponentLoader extends loader.ComponentLoader
       try
         source = CoffeeScript.compile source,
           bare: true
+      catch e
+        return callback e
+    else if language is 'es6'
+      try
+        source = babel.transform(source).code
       catch e
         return callback e
 


### PR DESCRIPTION
A follow up of https://github.com/noflo/noflo/pull/294

Huh, it seems running npm install babel-core --save sorted the dependencies of the package.json in alphabetical order for some reason... did it always work like that?