### PR TITLE
Updated cli to version 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "babel-core": "5.8.25",
-    "cli": "0.9.0",
+    "cli": "0.10.0",
     "cli-color": "0.3.3",
     "coffee-script": "1.10.0",
     "fbp": "1.1.2",


### PR DESCRIPTION
:rocket:

cli just published version 0.10.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 9 commits (ahead by 9, behind by 0).

- [432f5f7](https://github.com/chriso/cli/commit/432f5f7853e867400c462d699ecb57b71b0d2973): 0.10.0
- [f1a4700](https://github.com/chriso/cli/commit/f1a4700105af8a5e229a61386403ca2a3baa6b4f): Merge pull request #61 from meeech/issue-60
- [739b70b](https://github.com/chriso/cli/commit/739b70b62b37c5944425117aec3215106be7b921): Merge pull request #74 from RobertDeRose/Update-README-with-detailed-cli-parser-options
- [b2e6f49](https://github.com/chriso/cli/commit/b2e6f49737d58e5021a878d0f6f18eaadf416ad5): Grammar cleanup
- [239febe](https://github.com/chriso/cli/commit/239febee7fda91beaf3e465684096485a79f333b): Missed a "'"
- [af0089b](https://github.com/chriso/cli/commit/af0089bae19f06df59eb942bbad7eddb2ed91a67): Added more examples and fixed typo
- [060a813](https://github.com/chriso/cli/commit/060a81370a0058feb53699383833626dc28becb1): Added detailed Command Line parser method documentation
- [845a853](https://github.com/chriso/cli/commit/845a85393cccb0e82d96342e3bbe24d059fb244f): Add support for dates as command line arguments
- [4937c20](https://github.com/chriso/cli/commit/4937c20bc52d28ebc3e6614649ae90a7661d092f): fix #60

See the [full diff](https://github.com/chriso/cli/compare/87b200eadde1544a0481e34b19cb0f256b0ab3b9...432f5f7853e867400c462d699ecb57b71b0d2973).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>