### PR TITLE
IP objects

### DIFF
--- a/spec/Component.coffee
+++ b/spec/Component.coffee
@@ -245,9 +245,8 @@ describe 'Component', ->
       c.inPorts.in.attach s1
       c.outPorts.out.attach s2
 
-      i = new IP 'data', 'some-data'
-      i.groups = ['foo']
-      s1.post i
+      s1.post new IP 'data', 'some-data',
+        groups: ['foo']
 
     it 'should support substreams', (done) ->
       c = new component.Component

--- a/spec/Component.coffee
+++ b/spec/Component.coffee
@@ -2,9 +2,11 @@ if typeof process isnt 'undefined' and process.execPath and process.execPath.mat
   chai = require 'chai' unless chai
   component = require '../src/lib/Component.coffee'
   socket = require '../src/lib/InternalSocket.coffee'
+  IP = require '../src/lib/IP.coffee'
 else
   component = require 'noflo/src/lib/Component.js'
   socket = require 'noflo/src/lib/InternalSocket.js'
+  IP = require 'noflo/src/lib/IP.js'
 
 describe 'Component', ->
   describe 'with required ports', ->
@@ -206,3 +208,103 @@ describe 'Component', ->
       c.shutdown()
       chai.expect(c.started).to.equal(false)
       chai.expect(c.isStarted()).to.equal(false)
+
+  describe 'with object-based IPs', ->
+
+    it 'should speak IP objects', (done) ->
+      c = new component.Component
+        inPorts:
+          in:
+            datatype: 'string'
+            handle: (ip, component) ->
+              chai.expect(ip).to.be.an 'object'
+              chai.expect(ip.type).to.equal 'data'
+              chai.expect(ip.groups).to.be.an 'array'
+              chai.expect(ip.groups).to.eql ['foo']
+              chai.expect(ip.data).to.be.a 'string'
+              chai.expect(ip.data).to.equal 'some-data'
+
+              c.outPorts.out.data 'bar',
+                groups: ['foo']
+        outPorts:
+          out:
+            datatype: 'string'
+
+      s1 = new socket.InternalSocket
+      s2 = new socket.InternalSocket
+
+      s2.on 'data', (ip) ->
+        chai.expect(ip).to.be.an 'object'
+        chai.expect(ip.type).to.equal 'data'
+        chai.expect(ip.groups).to.be.an 'array'
+        chai.expect(ip.groups).to.eql ['foo']
+        chai.expect(ip.data).to.be.a 'string'
+        chai.expect(ip.data).to.equal 'bar'
+        done()
+
+      c.inPorts.in.attach s1
+      c.outPorts.out.attach s2
+
+      i = new IP 'data', 'some-data'
+      i.groups = ['foo']
+      s1.post i
+
+    it 'should support substreams', (done) ->
+      c = new component.Component
+        inPorts:
+          tags:
+            datatype: 'string'
+            handle: (ip) ->
+              chai.expect(ip).to.be.an 'object'
+              switch ip.type
+                when 'openBracket'
+                  c.str += "<#{ip.data}>"
+                  c.level++
+                when 'data'
+                  c.str += ip.data
+                when 'closeBracket'
+                  c.str += "</#{ip.data}>"
+                  c.level--
+                  if c.level is 0
+                    c.outPorts.html.data c.str
+                    c.str = ''
+        outPorts:
+          html:
+            datatype: 'string'
+      c.str = ''
+      c.level = 0
+
+      d = new component.Component
+        inPorts:
+          bang:
+            datatype: 'bang'
+            handle: (ip) ->
+              d.outPorts.tags.openBracket 'p'
+              .openBracket 'em'
+              .data 'Hello'
+              .closeBracket 'em'
+              .data ', '
+              .openBracket 'strong'
+              .data 'World!'
+              .closeBracket 'strong'
+              .closeBracket 'p'
+        outPorts:
+          tags:
+            datatype: 'string'
+
+      s1 = new socket.InternalSocket
+      s2 = new socket.InternalSocket
+      s3 = new socket.InternalSocket
+
+      s3.on 'data', (ip) ->
+        chai.expect(ip).to.be.an 'object'
+        chai.expect(ip.type).to.equal 'data'
+        chai.expect(ip.data).to.equal '<p><em>Hello</em>, <strong>World!</strong></p>'
+        done()
+
+      d.inPorts.bang.attach s1
+      d.outPorts.tags.attach s2
+      c.inPorts.tags.attach s2
+      c.outPorts.html.attach s3
+
+      s1.post new IP 'data', 'start'

--- a/spec/IP.coffee
+++ b/spec/IP.coffee
@@ -31,10 +31,10 @@ describe 'IP object', ->
     chai.expect(p.scope).to.equal 'request-12345'
 
   it 'should be able to clone itself', ->
-    d1 = new IP 'data', "Trooper"
-    d1.groups = ['foo', 'bar']
-    d1.owner = 'SomeProc'
-    d1.scope = 'request-12345'
+    d1 = new IP 'data', "Trooper",
+      groups: ['foo', 'bar']
+      owner: 'SomeProc'
+      scope: 'request-12345'
     d2 = d1.clone()
     chai.expect(d2).not.to.equal d1
     chai.expect(d2.type).to.equal d1.type

--- a/spec/IP.coffee
+++ b/spec/IP.coffee
@@ -1,0 +1,50 @@
+if typeof process isnt 'undefined' and process.execPath and process.execPath.match /node|iojs/
+  chai = require 'chai' unless chai
+  IP = require '../src/lib/IP'
+else
+  IP = require 'noflo/src/lib/IP'
+
+describe 'IP object', ->
+  it 'should create IPs of different types', ->
+    open = new IP 'openBracket'
+    data = new IP 'data', "Payload"
+    close = new IP 'closeBracket'
+    chai.expect(open.type).to.equal 'openBracket'
+    chai.expect(close.type).to.equal 'closeBracket'
+    chai.expect(data.type).to.equal 'data'
+
+  it 'should attach data groups explicitly', ->
+    data = new IP 'data', "Payload"
+    chai.expect(data.groups).to.be.an.instanceof Array
+    chai.expect(data.groups).to.have.lengthOf 0
+    data.groups = ['foo', 'bar']
+    chai.expect(data.groups).to.have.lengthOf 2
+
+  it 'should be moved to an owner', ->
+    p = new IP 'data', "Token"
+    p.move 'SomeProc'
+    chai.expect(p.owner).to.equal 'SomeProc'
+
+  it 'should support sync context scoping', ->
+    p = new IP 'data', "Request-specific"
+    p.scope = 'request-12345'
+    chai.expect(p.scope).to.equal 'request-12345'
+
+  it 'should be able to clone itself', ->
+    d1 = new IP 'data', "Trooper"
+    d1.groups = ['foo', 'bar']
+    d1.owner = 'SomeProc'
+    d1.scope = 'request-12345'
+    d2 = d1.clone()
+    chai.expect(d2).not.to.equal d1
+    chai.expect(d2.type).to.equal d1.type
+    chai.expect(d2.data).to.eql d1.data
+    chai.expect(d2.groups).to.eql d2.groups
+    chai.expect(d2.owner).not.to.equal d1.owner
+    chai.expect(d2.scope).to.equal d1.scope
+
+  it 'should dispose its contents when dropped', ->
+    p = new IP 'data', "Garbage"
+    p.groups = ['foo', 'bar']
+    p.drop()
+    chai.expect(Object.keys(p)).to.have.lengthOf 0

--- a/spec/InPort.coffee
+++ b/spec/InPort.coffee
@@ -260,7 +260,7 @@ describe 'Inport Port', ->
       chai.expect(ps.inPorts.in.listAttached()).to.eql [0]
       s.send type: 'data', data: 'some-data'
 
-    it 'should translate legacy events to IPs', (done) ->
+    it 'should translate legacy events to IP objects', (done) ->
       s = new socket.InternalSocket
       expectedEvents = [
         'openBracket'
@@ -288,3 +288,26 @@ describe 'Inport Port', ->
       chai.expect(ps.inPorts.in.listAttached()).to.eql [0]
       s.send 'some-data'
       s.disconnect()
+
+    it 'should translate IP objects to legacy events', (done) ->
+      s = new socket.InternalSocket
+      expectedEvents = [
+        'connect'
+        'data'
+        'disconnect'
+      ]
+      ps =
+        outPorts: new ports.OutPorts
+          out: new outport
+        inPorts: new ports.InPorts
+      ps.inPorts.add 'in',
+        datatype: 'string'
+        required: true
+      , (event, payload) ->
+        chai.expect(event).to.equal expectedEvents.shift()
+        return unless event is 'data'
+        chai.expect(payload).to.equal 'some-data'
+        done()
+      ps.inPorts.in.attach s
+      chai.expect(ps.inPorts.in.listAttached()).to.eql [0]
+      s.post type: 'data', data: 'some-data'

--- a/spec/OutPort.coffee
+++ b/spec/OutPort.coffee
@@ -123,3 +123,31 @@ describe 'Outport Port', ->
       p.disconnect 1
       p.detach s2
       p.attach s3, 1
+
+  describe 'with IP objects', ->
+    s1 = s2 = s3 = null
+    beforeEach ->
+      s1 = new socket.InternalSocket
+      s2 = new socket.InternalSocket
+      s3 = new socket.InternalSocket
+
+    it 'should send data IPs and substreams', (done) ->
+      p = new outport
+      p.attach s1
+      expectedEvents = [
+        'data'
+        'openBracket'
+        'data'
+        'closeBracket'
+      ]
+      count = 0
+      s1.on 'data', (data) ->
+        count++
+        chai.expect(data).to.be.an 'object'
+        chai.expect(data.type).to.equal expectedEvents.shift()
+        chai.expect(data.data).to.equal 'my-data' if data.type is 'data'
+        done() if count is 4
+      p.data 'my-data'
+      p.openBracket()
+      .data 'my-data'
+      .closeBracket()

--- a/src/lib/IP.coffee
+++ b/src/lib/IP.coffee
@@ -1,0 +1,30 @@
+module.exports = class IP
+  # Creates as new IP object
+  # Valid types: 'data', 'openBracket', 'closeBracket'
+  constructor: (@type = 'data', @data = null) ->
+    @groups = [] # sync groups
+    @scope = null # sync scope id
+    @stream = null # substream id
+    @owner = null # packet owner process
+
+  # Creates a new IP copying its contents by value not reference
+  clone: ->
+    ip = new IP
+    ip.type = @type
+    ip.data = JSON.parse JSON.stringify @data if @data isnt null
+    ip.groups = JSON.parse JSON.stringify @groups if @groups.length > 0
+    ip.scope = @scope # sync scope is preserved
+    ip
+
+  # Moves an IP to a different owner
+  move: (@owner) ->
+    # no-op
+
+  # Frees IP contents
+  drop: ->
+    delete @type
+    delete @data
+    delete @groups
+    delete @scope
+    delete @stream
+    delete @owner

--- a/src/lib/IP.coffee
+++ b/src/lib/IP.coffee
@@ -1,4 +1,10 @@
 module.exports = class IP
+  @types: [
+    'data'
+    'openBracket'
+    'closeBracket'
+  ]
+
   # Creates as new IP object
   # Valid types: 'data', 'openBracket', 'closeBracket'
   constructor: (@type = 'data', @data = null) ->

--- a/src/lib/IP.coffee
+++ b/src/lib/IP.coffee
@@ -7,11 +7,13 @@ module.exports = class IP
 
   # Creates as new IP object
   # Valid types: 'data', 'openBracket', 'closeBracket'
-  constructor: (@type = 'data', @data = null) ->
+  constructor: (@type = 'data', @data = null, options = {}) ->
     @groups = [] # sync groups
     @scope = null # sync scope id
     @stream = null # substream id
     @owner = null # packet owner process
+    for key, val of options
+      this[key] = val
 
   # Creates a new IP copying its contents by value not reference
   clone: ->

--- a/src/lib/InPort.coffee
+++ b/src/lib/InPort.coffee
@@ -40,7 +40,10 @@ class InPort extends BasePort
     # Assign a delegate for retrieving data should this inPort
     # have a default value.
     if @hasDefault()
-      socket.setDataDelegate => @options.default
+      if @handle
+        socket.setDataDelegate => new IP 'data', @options.default
+      else
+        socket.setDataDelegate => @options.default
 
     socket.on 'connect', =>
       @handleSocketEvent 'connect', socket, localId

--- a/src/lib/InPort.coffee
+++ b/src/lib/InPort.coffee
@@ -80,8 +80,7 @@ class InPort extends BasePort
         # Wrap legacy event
         switch event
           when 'connect', 'begingroup'
-            ip = new IP 'openBracket'
-            ip.groups = [ payload ] if payload
+            ip = new IP 'openBracket', payload
           when 'disconnect', 'endgroup'
             ip = new IP 'closeBracket'
           else

--- a/src/lib/InternalSocket.coffee
+++ b/src/lib/InternalSocket.coffee
@@ -89,7 +89,7 @@ class InternalSocket extends EventEmitter
   #
   # As _connect_ event is considered as open bracket, it needs to be followed
   # by a _disconnect_ event or a closing bracket. In the new simplified
-  # sending semantics sinle IP objects can be sent without open/close brackets.
+  # sending semantics single IP objects can be sent without open/close brackets.
   post: (data) ->
     data = @dataDelegate() if data is undefined and typeof @dataDelegate is 'function'
     @emitEvent 'data', data

--- a/src/lib/InternalSocket.coffee
+++ b/src/lib/InternalSocket.coffee
@@ -85,6 +85,15 @@ class InternalSocket extends EventEmitter
     data = @dataDelegate() if data is undefined and typeof @dataDelegate is 'function'
     @emitEvent 'data', data
 
+  # ## Sending information packets without open bracket
+  #
+  # As _connect_ event is considered as open bracket, it needs to be followed
+  # by a _disconnect_ event or a closing bracket. In the new simplified
+  # sending semantics sinle IP objects can be sent without open/close brackets.
+  post: (data) ->
+    data = @dataDelegate() if data is undefined and typeof @dataDelegate is 'function'
+    @emitEvent 'data', data
+
   # ## Information Packet grouping
   #
   # Processes sending data to sockets may also group the packets

--- a/src/lib/OutPort.coffee
+++ b/src/lib/OutPort.coffee
@@ -4,6 +4,7 @@
 #
 # Output Port (outport) implementation for NoFlo components
 BasePort = require './BasePort'
+IP = require './IP'
 
 class OutPort extends BasePort
   constructor: (options) ->
@@ -57,6 +58,26 @@ class OutPort extends BasePort
     for socket in sockets
       continue unless socket
       socket.disconnect()
+
+  sendIP: (type, data, options, socketId) ->
+    ip = new IP type, data
+    for key, val of options
+      ip[key] = val
+    sockets = @getSockets socketId
+    @checkRequired sockets
+    for socket in sockets
+      continue unless socket
+      socket.post ip
+    @
+
+  openBracket: (options, socketId = null) ->
+    @sendIP 'openBracket', null, options, socketId
+
+  data: (data, options, socketId = null) ->
+    @sendIP 'data', data, options, socketId
+
+  closeBracket: (options, socketId = null) ->
+    @sendIP 'closeBracket', null, options, socketId
 
   checkRequired: (sockets) ->
     if sockets.length is 0 and @isRequired()

--- a/src/lib/OutPort.coffee
+++ b/src/lib/OutPort.coffee
@@ -70,14 +70,14 @@ class OutPort extends BasePort
       socket.post ip
     @
 
-  openBracket: (options, socketId = null) ->
-    @sendIP 'openBracket', null, options, socketId
+  openBracket: (data = null, options = {}, socketId = null) ->
+    @sendIP 'openBracket', data, options, socketId
 
-  data: (data, options, socketId = null) ->
+  data: (data, options = {}, socketId = null) ->
     @sendIP 'data', data, options, socketId
 
-  closeBracket: (options, socketId = null) ->
-    @sendIP 'closeBracket', null, options, socketId
+  closeBracket: (data = null, options = {}, socketId = null) ->
+    @sendIP 'closeBracket', data, options, socketId
 
   checkRequired: (sockets) ->
     if sockets.length is 0 and @isRequired()

--- a/src/lib/OutPort.coffee
+++ b/src/lib/OutPort.coffee
@@ -60,11 +60,11 @@ class OutPort extends BasePort
       socket.disconnect()
 
   sendIP: (type, data, options, socketId) ->
-    ip = new IP type, data
-    for key, val of options
-      ip[key] = val
+    ip = new IP type, data, options
     sockets = @getSockets socketId
     @checkRequired sockets
+    if @isCaching() and data isnt @cache[socketId]?.data
+      @cache[socketId] = ip
     for socket in sockets
       continue unless socket
       socket.post ip


### PR DESCRIPTION
This is the implementation of #290 on port and socket level.

For example use in components see 2 test cases here: https://github.com/trustmaster/noflo/blob/ip-objects/spec/Component.coffee#L212

I had to pick some new method names to keep the old API fully available.

The `InPort` [maintains](https://github.com/trustmaster/noflo/blob/ip-objects/spec/InPort.coffee#L263) compatibility layer between the old raw packets with 7 event types and the new object packets with 1 event type. So the old-style components can be combined with new-style components within the same graph.

I've added [`InternalSocket.post()`](https://github.com/trustmaster/noflo/blob/ip-objects/src/lib/InternalSocket.coffee#L93) method because connect/disconnect events are now considered as optional. This is to avoid the annoying `disconnect()` every time you just want to send a single packet, and to avoid littering the compatibility layer with unnecessary `openBracket/closeBracket` packets.

Comments and suggestions are welcome.

### TODO

 - [ ] Describe packet cloning use cases
 - [ ] Improve/implement cloning interfaces and underlying code
 - [ ] Add `IP.toString()` method providing as much sensitive debug information as possible

Will fix #290
Also fixes #162