### PR TITLE
Allow graph.loadFile and noflo.createNetwork to return errors

### DIFF
--- a/spec/Graph.coffee
+++ b/spec/Graph.coffee
@@ -233,7 +233,8 @@ describe 'Graph', ->
     json = JSON.parse(jsonString)
     g = null
     it 'should produce a Graph', (done) ->
-      graph.loadJSON json, (instance) ->
+      graph.loadJSON json, (err, instance) ->
+        return done err if err
         g = instance
         chai.expect(g).to.be.an 'object'
         done()
@@ -575,7 +576,8 @@ describe 'Graph', ->
     json = JSON.parse(jsonString)
     g = null
     it 'should produce a Graph', (done) ->
-      graph.loadJSON json, (instance) ->
+      graph.loadJSON json, (err, instance) ->
+        return done err if err
         g = instance
         chai.expect(g).to.be.an 'object'
         done()

--- a/spec/Journal.coffee
+++ b/spec/Journal.coffee
@@ -201,14 +201,17 @@ describe 'Journalling of graph merges', ->
   j = null
   describe 'G -> B', ->
     it 'G starts out as A', (done) ->
-      graph.loadJSON JSON.parse(A), (instance) ->
+      graph.loadJSON JSON.parse(A), (err, instance) ->
+        return done err if err
         a = instance
-        graph.loadJSON JSON.parse(A), (instance) ->
+        graph.loadJSON JSON.parse(A), (err, instance) ->
+          return done err if err
           g = instance
           chai.expect(graph.equivalent(a, g)).to.equal true
           done()
     it 'G and B starts out different', (done) ->
-      graph.loadJSON JSON.parse(B), (instance) ->
+      graph.loadJSON JSON.parse(B), (err, instance) ->
+        return done err if err
         b = instance
         chai.expect(graph.equivalent(g, b)).to.equal false
         done()

--- a/spec/Network.coffee
+++ b/spec/Network.coffee
@@ -113,12 +113,14 @@ describe 'NoFlo Network', ->
       g.addNode 'Merge', 'Merge'
       g.addNode 'Callback', 'Callback'
       g.addEdge 'Merge', 'out', 'Callback', 'in'
-      noflo.createNetwork g, (nw) ->
+      noflo.createNetwork g, (err, nw) ->
+        return done err if err
         nw.loader.components.Split = Split
         nw.loader.components.Merge = Merge
         nw.loader.components.Callback = Callback
         n = nw
-        nw.connect ->
+        nw.connect (err) ->
+          return done err if err
           nw.start()
           done()
       , true
@@ -247,10 +249,12 @@ describe 'NoFlo Network', ->
       testCallback = (data) ->
         chai.expect(data).to.equal 'default-value'
         done()
-      noflo.createNetwork g, (nw) ->
+      noflo.createNetwork g, (err, nw) ->
+        return done err if err
         nw.loader.components.Def = -> c
         nw.loader.components.Cb = -> cb
-        nw.connect ->
+        nw.connect (err) ->
+          return done err if err
           nw.start()
       , true
 
@@ -262,11 +266,13 @@ describe 'NoFlo Network', ->
       g.addNode 'Merge', 'Merge'
       g.addEdge 'Merge', 'out', 'Def', 'in'
       g.addInitial 'from-edge', 'Merge', 'in'
-      noflo.createNetwork g, (nw) ->
+      noflo.createNetwork g, (err, nw) ->
+        return done err if err
         nw.loader.components.Def = -> c
         nw.loader.components.Cb = -> cb
         nw.loader.components.Merge = Merge
-        nw.connect ->
+        nw.connect (err) ->
+          return done err if err
           nw.start()
       , true
 
@@ -276,11 +282,13 @@ describe 'NoFlo Network', ->
         chai.expect(data).to.equal 'from-IIP'
         done()
       g.addInitial 'from-IIP', 'Def', 'in'
-      noflo.createNetwork g, (nw) ->
+      noflo.createNetwork g, (err, nw) ->
+        return done err if err
         nw.loader.components.Def = -> c
         nw.loader.components.Cb = -> cb
         nw.loader.components.Merge = Merge
-        nw.connect ->
+        nw.connect (err) ->
+          return done err if err
           nw.start()
       , true
 
@@ -337,12 +345,14 @@ describe 'NoFlo Network', ->
       expected[12] = g.addInitial "World", "C", "in"
       expected[8] = g.addEdge "B2", "out", "C", "in"
       expected[9] = g.addEdge "C", "out", "D", "in"
-      noflo.createNetwork g, (nw) ->
+      noflo.createNetwork g, (err, nw) ->
+        return done err if err
         nw.loader.components.Split = Split
         nw.loader.components.Merge = Merge
         nw.loader.components.Callback = Callback
         n = nw
-        nw.connect ->
+        nw.connect (err) ->
+          return done err if err
           nw.start()
           done()
       , true
@@ -369,12 +379,14 @@ describe 'NoFlo Network', ->
       g.addInitial cb, 'Callback', 'callback'
       g.addInitial 'Foo', 'Repeat', 'in'
       setTimeout ->
-        noflo.createNetwork g, (nw) ->
+        noflo.createNetwork g, (err, nw) ->
+          return done err if err
           nw.loader.components.Split = Split
           nw.loader.components.Merge = Merge
           nw.loader.components.Callback = Callback
           n = nw
-          nw.connect ->
+          nw.connect (err) ->
+            return done err if err
             nw.start()
         , true
       , 10

--- a/src/components/Graph.coffee
+++ b/src/components/Graph.coffee
@@ -38,7 +38,8 @@ class Graph extends noflo.Component
     if graph.substr(0, 1) isnt "/" and graph.substr(1, 1) isnt ":" and process and process.cwd
       graph = "#{process.cwd()}/#{graph}"
 
-    graph = noflo.graph.loadFile graph, (instance) =>
+    graph = noflo.graph.loadFile graph, (err, instance) =>
+      return @error err if err
       instance.baseDir = @baseDir
       @createNetwork instance
 

--- a/src/components/Graph.coffee
+++ b/src/components/Graph.coffee
@@ -30,7 +30,8 @@ class Graph extends noflo.Component
         return @createNetwork graph
 
       # JSON definition of a graph
-      noflo.graph.loadJSON graph, (instance) =>
+      noflo.graph.loadJSON graph, (err, instance) =>
+        return @error err if err
         instance.baseDir = @baseDir
         @createNetwork instance
       return

--- a/src/components/Graph.coffee
+++ b/src/components/Graph.coffee
@@ -50,9 +50,11 @@ class Graph extends noflo.Component
 
     graph.componentLoader = @loader
 
-    noflo.createNetwork graph, (@network) =>
+    noflo.createNetwork graph, (err, @network) =>
+      return @error err if err
       @emit 'network', @network
-      @network.connect =>
+      @network.connect (err) =>
+        return @error err if err
         notReady = false
         for name, process of @network.processes
           notReady = true unless @checkComponent name, process

--- a/src/lib/ComponentLoader.coffee
+++ b/src/lib/ComponentLoader.coffee
@@ -269,7 +269,8 @@ class ComponentLoader extends EventEmitter
       nameParts[0] = ''
 
     if @isGraph component
-      nofloGraph.loadFile component, (graph) ->
+      nofloGraph.loadFile component, (err, graph) ->
+        return callback err if err
         return callback new Error 'Unable to load graph' unless graph
         callback null,
           name: nameParts[1]

--- a/src/lib/Graph.coffee
+++ b/src/lib/Graph.coffee
@@ -754,18 +754,18 @@ class Graph extends EventEmitter
 
     json
 
-  save: (file, success) ->
+  save: (file, callback) ->
     json = JSON.stringify @toJSON(), null, 4
     require('fs').writeFile "#{file}.json", json, "utf-8", (err, data) ->
       throw err if err
-      success file
+      callback file
 
 exports.Graph = Graph
 
 exports.createGraph = (name) ->
   new Graph name
 
-exports.loadJSON = (definition, success, metadata = {}) ->
+exports.loadJSON = (definition, callback, metadata = {}) ->
   definition = JSON.parse definition if typeof definition is 'string'
   definition.properties = {} unless definition.properties
   definition.processes = {} unless definition.processes
@@ -828,27 +828,26 @@ exports.loadJSON = (definition, success, metadata = {}) ->
 
   graph.endTransaction 'loadJSON'
 
-  success null, graph
+  callback null, graph
 
-exports.loadFBP = (fbpData, success) ->
+exports.loadFBP = (fbpData, callback) ->
   try
     definition = require('fbp').parse fbpData
   catch e
-    return success e
-  exports.loadJSON definition, success
+    return callback e
+  exports.loadJSON definition, callback
 
-exports.loadHTTP = (url, success) ->
+exports.loadHTTP = (url, callback) ->
   req = new XMLHttpRequest
   req.onreadystatechange = ->
     return unless req.readyState is 4
     unless req.status is 200
-      return success new Error "Failed to load #{url}: HTTP #{req.status}"
-    return success() unless req.status is 200
-    success null, eq.responseText
+      return callback new Error "Failed to load #{url}: HTTP #{req.status}"
+    callback null, eq.responseText
   req.open 'GET', url, true
   req.send()
 
-exports.loadFile = (file, success, metadata = {}) ->
+exports.loadFile = (file, callback, metadata = {}) ->
   if platform.isBrowser()
     try
       # Graph exposed via Component packaging
@@ -860,21 +859,21 @@ exports.loadFile = (file, success, metadata = {}) ->
           throw new Error "Failed to load graph #{file}"
           return
         if file.split('.').pop() is 'fbp'
-          return exports.loadFBP data, success, metadata
+          return exports.loadFBP data, callback, metadata
         definition = JSON.parse data
-        exports.loadJSON definition, success, metadata
+        exports.loadJSON definition, callback, metadata
       return
-    exports.loadJSON definition, success, metadata
+    exports.loadJSON definition, callback, metadata
     return
   # Node.js graph file
   require('fs').readFile file, "utf-8", (err, data) ->
-    retuen success err if err
+    return callback err if err
 
     if file.split('.').pop() is 'fbp'
-      return exports.loadFBP data, success
+      return exports.loadFBP data, callback
 
     definition = JSON.parse data
-    exports.loadJSON definition, success
+    exports.loadJSON definition, callback
 
 # remove everything in the graph
 resetGraph = (graph) ->

--- a/src/lib/NoFlo.coffee
+++ b/src/lib/NoFlo.coffee
@@ -83,7 +83,7 @@ exports.internalSocket = require('./InternalSocket')
 # This function handles instantiation of NoFlo networks from a Graph object. It creates
 # the network, and then starts execution by sending the Initial Information Packets.
 #
-#     noflo.createNetwork(someGraph, function (network) {
+#     noflo.createNetwork(someGraph, function (err, network) {
 #       console.log('Network is now running!');
 #     });
 #
@@ -91,8 +91,11 @@ exports.internalSocket = require('./InternalSocket')
 # third `delay` parameter. In this case you will have to handle connecting the graph and
 # sending of IIPs manually.
 #
-#     noflo.createNetwork(someGraph, function (network) {
-#       network.connect(function () {
+#     noflo.createNetwork(someGraph, function (err, network) {
+#       if (err) {
+#         throw err;
+#       }
+#       network.connect(function (err) {
 #         network.start();
 #         console.log('Network is now running!');
 #       })
@@ -105,7 +108,7 @@ exports.createNetwork = (graph, callback, options) ->
   network = new exports.Network graph, options
 
   networkReady = (network) ->
-    callback network if callback?
+    callback null, network if callback?
     # Send IIPs
     network.start()
 
@@ -116,10 +119,12 @@ exports.createNetwork = (graph, callback, options) ->
 
     # In case of delayed execution we don't wire it up
     if options.delay
-      callback network if callback?
+      callback null, network if callback?
       return
     # Wire the network up and start execution
-    network.connect -> networkReady network
+    network.connect (err) ->
+      return callback err if err
+      networkReady network
 
   network
 
@@ -128,7 +133,10 @@ exports.createNetwork = (graph, callback, options) ->
 # It is also possible to start a NoFlo network by giving it a path to a `.json` or `.fbp` network
 # definition file.
 #
-#     noflo.loadFile('somefile.json', function (network) {
+#     noflo.loadFile('somefile.json', function (err, network) {
+#       if (err) {
+#         throw err;
+#       }
 #       console.log('Network is now running!');
 #     });
 exports.loadFile = (file, options, callback) ->

--- a/src/lib/NoFlo.coffee
+++ b/src/lib/NoFlo.coffee
@@ -140,7 +140,8 @@ exports.loadFile = (file, options, callback) ->
     options =
       baseDir: options
 
-  exports.graph.loadFile file, (net) ->
+  exports.graph.loadFile file, (err, net) ->
+    return callback err if err
     net.baseDir = options.baseDir if options.baseDir
     exports.createNetwork net, callback, options
 

--- a/src/lib/nodejs/ComponentLoader.coffee
+++ b/src/lib/nodejs/ComponentLoader.coffee
@@ -261,7 +261,8 @@ class ComponentLoader extends loader.ComponentLoader
       nameParts[0] = ''
 
     if @isGraph component
-      nofloGraph.loadFile component, (graph) ->
+      nofloGraph.loadFile component, (err, graph) ->
+        return callback err if err
         return callback new Error 'Unable to load graph' unless graph
         callback null,
           name: nameParts[1]


### PR DESCRIPTION
This is to improve error handling when users have missing or faulty components.