### PR TITLE
Clonable IP semantics

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ NoFlo ChangeLog
 * Deprecated the `noflo` command in favor of [noflo-nodejs](https://www.npmjs.com/package/noflo-nodejs)
 * NoFlo `createNetwork` and `loadFile` methods can return errors as the first callback argument
 * New [IP Objects](https://github.com/noflo/noflo/issues/290) feature allowing bundling and handling of groups and packet data together
+* New option to enable [cloning of packets](https://github.com/noflo/noflo/pull/375) when sending to multiple outbound connections
 * Removed the deprecated `LoggingComponent` baseclass
 
 ## 0.5.21 (December 3rd 2015)

--- a/spec/IP.coffee
+++ b/spec/IP.coffee
@@ -35,6 +35,7 @@ describe 'IP object', ->
       groups: ['foo', 'bar']
       owner: 'SomeProc'
       scope: 'request-12345'
+      clonable: true
     d2 = d1.clone()
     chai.expect(d2).not.to.equal d1
     chai.expect(d2.type).to.equal d1.type

--- a/src/lib/IP.coffee
+++ b/src/lib/IP.coffee
@@ -11,16 +11,21 @@ module.exports = class IP
     @groups = [] # sync groups
     @scope = null # sync scope id
     @owner = null # packet owner process
+    @clonable = true # cloning safety flag
     for key, val of options
       this[key] = val
 
   # Creates a new IP copying its contents by value not reference
   clone: ->
-    ip = new IP
-    ip.type = @type
-    ip.data = JSON.parse JSON.stringify @data if @data isnt null
-    ip.groups = JSON.parse JSON.stringify @groups if @groups.length > 0
-    ip.scope = @scope # sync scope is preserved
+    return @ unless @clonable
+    ip = new IP @type
+    for key, val of @
+      continue if ['owner'].indexOf(key) isnt -1
+      continue if val is null
+      if typeof(val) is 'object'
+        ip[key] = JSON.parse JSON.stringify val
+      else
+        ip[key] = val
     ip
 
   # Moves an IP to a different owner
@@ -29,8 +34,4 @@ module.exports = class IP
 
   # Frees IP contents
   drop: ->
-    delete @type
-    delete @data
-    delete @groups
-    delete @scope
-    delete @owner
+    delete this[key] for key, val of @

--- a/src/lib/IP.coffee
+++ b/src/lib/IP.coffee
@@ -10,7 +10,6 @@ module.exports = class IP
   constructor: (@type = 'data', @data = null, options = {}) ->
     @groups = [] # sync groups
     @scope = null # sync scope id
-    @stream = null # substream id
     @owner = null # packet owner process
     for key, val of options
       this[key] = val
@@ -34,5 +33,4 @@ module.exports = class IP
     delete @data
     delete @groups
     delete @scope
-    delete @stream
     delete @owner

--- a/src/lib/IP.coffee
+++ b/src/lib/IP.coffee
@@ -11,13 +11,12 @@ module.exports = class IP
     @groups = [] # sync groups
     @scope = null # sync scope id
     @owner = null # packet owner process
-    @clonable = true # cloning safety flag
+    @clonable = false # cloning safety flag
     for key, val of options
       this[key] = val
 
   # Creates a new IP copying its contents by value not reference
   clone: ->
-    return @ unless @clonable
     ip = new IP @type
     for key, val of @
       continue if ['owner'].indexOf(key) isnt -1

--- a/src/lib/OutPort.coffee
+++ b/src/lib/OutPort.coffee
@@ -65,9 +65,14 @@ class OutPort extends BasePort
     @checkRequired sockets
     if @isCaching() and data isnt @cache[socketId]?.data
       @cache[socketId] = ip
+    pristine = true
     for socket in sockets
       continue unless socket
-      socket.post ip
+      if pristine
+        socket.post ip
+        pristine = false
+      else
+        socket.post if ip.clonable then ip.clone() else ip
     @
 
   openBracket: (data = null, options = {}, socketId = null) ->


### PR DESCRIPTION
This PR adds `IP.clonable` property with the following semantics:

- `IP.clonable` property is `false` by default. Objects are not cloned on send to maintain backwards compatibility and avoid performance trade-offs.
- When `clonable` property of an IP is set `true` and there are multiple connections attached to the same output port, the output port will create a new clone of the IP object before sending it to a subsequent connection.

An example of sending an object to output and setting it explicitly clonable:

```coffeescript
# Some complex object
obj =
  num: 123
  nested:
    str: 'my-string'
    deeper:
      val: 432
  func: (str) ->
    console.log str

# Sending it with cloning semantics
component.outPorts.result.data obj,
  clonable: true
```

In the above example every consumer of the `result` outport will receive a new copy of `obj` which will contain nested properties `num`, `str` and `nested` equal to such of the original object, but `func` property  will be `undefined` in the clones because functions are not persisted when cloning objects.