### PR TITLE
Network start callback

### DIFF
--- a/src/lib/NoFlo.coffee
+++ b/src/lib/NoFlo.coffee
@@ -111,9 +111,10 @@ exports.createNetwork = (graph, callback, options) ->
   network = new exports.Network graph, options
 
   networkReady = (network) ->
-    callback null, network
     # Send IIPs
-    network.start()
+    network.start (err) ->
+      return callback err if err
+      callback null, network
 
   # Ensure components are loaded before continuing
   network.loader.listComponents ->
@@ -124,6 +125,7 @@ exports.createNetwork = (graph, callback, options) ->
     if options.delay
       callback null, network
       return
+
     # Wire the network up and start execution
     network.connect (err) ->
       return callback err if err


### PR DESCRIPTION
This PR provides a callback for `network.start` which is called when all components have started, defaults and IIPs have been sent`.

We also utilize the callback for `noflo.loadFile` to send IIPs before returning callback if not in delayed mode.

Will fix #261