### PR TITLE
Switch component loading to fbp-manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .node_shell
-node_modules
+/node_modules/
 /components/
 /browser/
 bin/*.js

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@ NoFlo ChangeLog
 
 ## 0.7.0 (git master)
 
-* Switched component discovery and caching from `read-installed` to [FBP manifest](https://github.com/flowbased/fbp-manifest)
+* Switched component discovery and caching from `read-installed` to [FBP manifest](https://github.com/flowbased/fbp-manifest). `fbp.json` files can be generated using `noflo-cache-preheat`.
 
 ## 0.6.1 (March 20th 2016)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 NoFlo ChangeLog
 ===============
 
+## 0.7.0 (git master)
+
+* Switched component discovery and caching from `read-installed` to [FBP manifest](https://github.com/flowbased/fbp-manifest)
+
 ## 0.6.1 (March 20th 2016)
 
 * NoFlo's IP Objects are now available via `noflo.IP`

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,5 +19,5 @@ build: off
 test_script:
   - node --version
   - npm --version
-  - ps: grunt test --no-color # PowerShell
-  - cmd: grunt test --no-color
+  - ps: grunt test:nodejs --no-color # PowerShell
+  - cmd: grunt test:nodejs --no-color

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,5 +19,4 @@ build: off
 test_script:
   - node --version
   - npm --version
-  - ps: grunt test:nodejs --no-color # PowerShell
   - cmd: grunt test:nodejs --no-color

--- a/bin/noflo-cache-preheat
+++ b/bin/noflo-cache-preheat
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // vim: set filetype=javascript:
-var noflo = require('noflo');
+var noflo = require('../lib/NoFlo');
 var path = require('path');
 var fs = require('fs');
 

--- a/bin/noflo-cache-preheat
+++ b/bin/noflo-cache-preheat
@@ -6,7 +6,7 @@ var fs = require('fs');
 
 // Base setup
 var baseDir = process.cwd();
-var cacheFile = path.resolve(baseDir, '.noflo.json');
+var cacheFile = path.resolve(baseDir, 'fbp.json');
 
 var preheat = function (callback) {
   console.log("Pre-heating NoFlo cache for " + baseDir);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "babel-core": "6.7.4",
     "coffee-script": "1.10.0",
     "fbp": "1.1.4",
-    "fbp-manifest": "^0.1.2",
+    "fbp-manifest": "^0.1.4",
     "underscore": "1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
     "babel-core": "6.7.4",
     "coffee-script": "1.10.0",
     "fbp": "1.1.4",
-    "npmlog": "2.0.3",
-    "read-installed": "4.0.3",
+    "fbp-manifest": "^0.1.2",
     "underscore": "1.8.3"
   },
   "devDependencies": {

--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -289,3 +289,37 @@ describe 'ComponentLoader with no external packages installed', ->
           chai.expect(err).to.be.an 'error'
           chai.expect(inst).to.be.an 'undefined'
           done()
+
+describe 'ComponentLoader with a fixture project', ->
+  l = null
+  before ->
+    return @skip() if platform.isBrowser()
+  it 'should be possible to instantiate', ->
+    l = new loader.ComponentLoader path.resolve __dirname, 'fixtures/componentloader'
+  it 'should initially know of no components', ->
+    chai.expect(l.components).to.be.a 'null'
+  it 'should not initially be ready', ->
+    chai.expect(l.ready).to.be.false
+  it 'should be able to read a list of components', (done) ->
+    ready = false
+    l.once 'ready', ->
+      chai.expect(l.ready).to.equal true
+      ready = l.ready
+    l.listComponents (components) ->
+      chai.expect(l.processing).to.equal false
+      chai.expect(l.components).not.to.be.empty
+      chai.expect(components).to.equal l.components
+      chai.expect(l.ready).to.equal true
+      chai.expect(ready).to.equal true
+      done()
+    chai.expect(l.processing).to.equal true
+  it 'should be able to load the local component', (done) ->
+    l.load 'componentloader/Output', (err, instance) ->
+      chai.expect(err).to.be.a 'null'
+      chai.expect(instance.description).to.equal 'Output stuff'
+      chai.expect(instance.icon).to.equal 'cloud'
+      done()
+  it 'should fail loading a missing component', (done) ->
+    l.load 'componentloader/Missing', (err, instance) ->
+      chai.expect(err).to.be.an 'error'
+      done()

--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -325,6 +325,12 @@ describe 'ComponentLoader with a fixture project', ->
       chai.expect(instance.description).to.equal 'Forward stuff'
       chai.expect(instance.icon).to.equal 'car'
       done()
+  it 'should be able to load a dynamically registered component from a dependency', (done) ->
+    l.load 'example/Hello', (err, instance) ->
+      chai.expect(err).to.be.a 'null'
+      chai.expect(instance.description).to.equal 'Hello stuff'
+      chai.expect(instance.icon).to.equal 'bicycle'
+      done()
   it 'should be able to load core Graph component', (done) ->
     l.load 'Graph', (err, instance) ->
       chai.expect(err).to.be.a 'null'

--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -325,6 +325,11 @@ describe 'ComponentLoader with a fixture project', ->
       chai.expect(instance.description).to.equal 'Forward stuff'
       chai.expect(instance.icon).to.equal 'car'
       done()
+  it 'should be able to load core Graph component', (done) ->
+    l.load 'Graph', (err, instance) ->
+      chai.expect(err).to.be.a 'null'
+      chai.expect(instance.icon).to.equal 'sitemap'
+      done()
   it 'should fail loading a missing component', (done) ->
     l.load 'componentloader/Missing', (err, instance) ->
       chai.expect(err).to.be.an 'error'

--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -313,11 +313,17 @@ describe 'ComponentLoader with a fixture project', ->
       chai.expect(ready).to.equal true
       done()
     chai.expect(l.processing).to.equal true
-  it 'should be able to load the local component', (done) ->
+  it 'should be able to load a local component', (done) ->
     l.load 'componentloader/Output', (err, instance) ->
       chai.expect(err).to.be.a 'null'
       chai.expect(instance.description).to.equal 'Output stuff'
       chai.expect(instance.icon).to.equal 'cloud'
+      done()
+  it 'should be able to load a component from a dependency', (done) ->
+    l.load 'example/Forward', (err, instance) ->
+      chai.expect(err).to.be.a 'null'
+      chai.expect(instance.description).to.equal 'Forward stuff'
+      chai.expect(instance.icon).to.equal 'car'
       done()
   it 'should fail loading a missing component', (done) ->
     l.load 'componentloader/Missing', (err, instance) ->

--- a/spec/fixtures/componentloader/components/Output.coffee
+++ b/spec/fixtures/componentloader/components/Output.coffee
@@ -1,0 +1,15 @@
+noflo = require '../../../../src/lib/NoFlo'
+
+exports.getComponent = ->
+  c = new noflo.Component
+  c.description = "Output stuff"
+  c.inPorts.add 'in',
+    datatype: 'string'
+  c.inPorts.add 'out',
+    datatype: 'string'
+  c.process = (input, output) ->
+    data = input.getData 'in'
+    console.log data
+    output.sendDone
+      out: data
+  c

--- a/spec/fixtures/componentloader/node_modules/example/components/Forward.coffee
+++ b/spec/fixtures/componentloader/node_modules/example/components/Forward.coffee
@@ -1,0 +1,14 @@
+noflo = require '../../../../../../src/lib/NoFlo'
+
+exports.getComponent = ->
+  c = new noflo.Component
+  c.description = "Forward stuff"
+  c.inPorts.add 'in',
+    datatype: 'all'
+  c.inPorts.add 'out',
+    datatype: 'all'
+  c.process = (input, output) ->
+    data = input.getData 'in'
+    output.sendDone
+      out: data
+  c

--- a/spec/fixtures/componentloader/node_modules/example/loader.coffee
+++ b/spec/fixtures/componentloader/node_modules/example/loader.coffee
@@ -14,3 +14,4 @@ module.exports = (loader, callback) ->
       output.sendDone
         out: data
     c
+  callback null

--- a/spec/fixtures/componentloader/node_modules/example/loader.coffee
+++ b/spec/fixtures/componentloader/node_modules/example/loader.coffee
@@ -1,0 +1,16 @@
+noflo = require '../../../../../src/lib/NoFlo'
+
+module.exports = (loader, callback) ->
+  loader.registerComponent 'example', 'Hello', ->
+    c = new noflo.Component
+    c.description = "Hello stuff"
+    c.icon = 'bicycle'
+    c.inPorts.add 'in',
+      datatype: 'all'
+    c.inPorts.add 'out',
+      datatype: 'all'
+    c.process = (input, output) ->
+      data = input.getData 'in'
+      output.sendDone
+        out: data
+    c

--- a/spec/fixtures/componentloader/node_modules/example/package.json
+++ b/spec/fixtures/componentloader/node_modules/example/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "example",
+  "noflo": {
+    "icon": "car",
+    "components": {
+      "Forward": "components/Forward.coffee"
+    }
+  }
+}

--- a/spec/fixtures/componentloader/node_modules/example/package.json
+++ b/spec/fixtures/componentloader/node_modules/example/package.json
@@ -2,6 +2,7 @@
   "name": "example",
   "noflo": {
     "icon": "car",
+    "loader": "loader.coffee",
     "components": {
       "Forward": "components/Forward.coffee"
     }

--- a/spec/fixtures/componentloader/package.json
+++ b/spec/fixtures/componentloader/package.json
@@ -5,5 +5,8 @@
     "components": {
       "Output": "components/Output.coffee"
     }
+  },
+  "dependencies": {
+    "example": ""
   }
 }

--- a/spec/fixtures/componentloader/package.json
+++ b/spec/fixtures/componentloader/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "componentloader",
+  "noflo": {
+    "icon": "cloud",
+    "components": {
+      "Output": "components/Output.coffee"
+    }
+  }
+}

--- a/src/lib/nodejs/ComponentLoader.coffee
+++ b/src/lib/nodejs/ComponentLoader.coffee
@@ -47,7 +47,10 @@ class ComponentLoader extends loader.ComponentLoader
         @components["#{m.name}/#{c.name}"] = path.resolve @baseDir, c.path
 
     # Inject subgraph component
-    @components.Graph = path.resolve __dirname, '../../components/Graph'
+    if path.extname(__filename) is '.js'
+      @components.Graph = path.resolve __dirname, '../../components/Graph.js'
+    else
+      @components.Graph = path.resolve __dirname, '../../components/Graph.coffee'
 
   listComponents: (callback) ->
     if @processing

--- a/src/lib/nodejs/ComponentLoader.coffee
+++ b/src/lib/nodejs/ComponentLoader.coffee
@@ -43,6 +43,13 @@ class ComponentLoader extends loader.ComponentLoader
     compatible = modules.filter (m) -> m.runtime in ['noflo', 'noflo-nodejs']
     for m in compatible
       @libraryIcons[m.name] = m.icon if m.icon
+
+      if m.noflo?.loader
+        loaderPath = path.resolve @baseDir, m.base, m.noflo.loader
+        @componentLoaders.push loaderPath
+        loader = require loaderPath
+        @registerLoader loader, ->
+
       for c in m.components
         @components["#{m.name}/#{c.name}"] = path.resolve @baseDir, c.path
 

--- a/src/lib/nodejs/ComponentLoader.coffee
+++ b/src/lib/nodejs/ComponentLoader.coffee
@@ -5,7 +5,6 @@
 #
 # This is the Node.js version of the ComponentLoader.
 
-reader = require 'read-installed'
 {_} = require 'underscore'
 path = require 'path'
 fs = require 'fs'
@@ -13,6 +12,7 @@ loader = require '../ComponentLoader'
 internalSocket = require '../InternalSocket'
 utils = require '../Utils'
 nofloGraph = require '../Graph'
+manifest = require 'fbp-manifest'
 
 # We allow components to be un-compiled CoffeeScript
 CoffeeScript = require 'coffee-script'
@@ -20,125 +20,34 @@ if typeof CoffeeScript.register != 'undefined'
   CoffeeScript.register()
 babel = require 'babel-core'
 
-# Disable NPM logging in normal NoFlo operation
-log = require 'npmlog'
-log.pause()
-
 class ComponentLoader extends loader.ComponentLoader
-  getModuleComponents: (moduleDef, callback) ->
-    components = {}
-    @checked.push moduleDef.name
-
-    depCount = _.keys(moduleDef.dependencies).length
-    done = _.after depCount + 1, =>
-      callback components
-
-    # Handle sub-modules
-    _.each moduleDef.dependencies, (def) =>
-      return done() unless def.name?
-      return done() unless @checked.indexOf(def.name) is -1
-      @getModuleComponents def, (depComponents) ->
-        return done() if _.isEmpty depComponents
-        components[name] = cPath for name, cPath of depComponents
-        done()
-
-    # No need for further processing for non-NoFlo projects
-    return done() unless moduleDef.noflo
-
-    checkOwn = (def) =>
-      # Handle own components
-      prefix = @getModulePrefix def.name
-
-      # See if the library has a default icon
-      if def.noflo.icon
-        @libraryIcons[prefix] = def.noflo.icon
-
-      if def.noflo.components
-        for name, cPath of def.noflo.components
-          @registerComponent prefix, name, path.resolve def.realPath, cPath
-      if moduleDef.noflo.graphs
-        for name, gPath of def.noflo.graphs
-          @registerGraph prefix, name, path.resolve def.realPath, gPath
-      if def.noflo.loader
-        # Run a custom component loader
-        loaderPath = path.resolve def.realPath, def.noflo.loader
-        @componentLoaders = [] unless @componentLoaders
-        @componentLoaders.push loaderPath
-        loader = require loaderPath
-        @registerLoader loader, done
-      else
-        done()
-
-    # Normally we can rely on the module data we get from read-installed, but in
-    # case cache has been cleared, we must re-read the file
-    unless @revalidate
-      return checkOwn moduleDef
-    @readPackageFile "#{moduleDef.realPath}/package.json", (err, data) ->
-      return done() if err
-      checkOwn data
-
-  getCoreComponents: (callback) ->
-    # Read core components
-    # TODO: These components should eventually be migrated to modules too
-    corePath = path.resolve __dirname, '../../src/components'
-    if path.extname(__filename) is '.coffee'
-      # Handle the non-compiled version of ComponentLoader for unit tests
-      corePath = path.resolve __dirname, '../../components'
-
-    fs.readdir corePath, (err, components) =>
-      coreComponents = {}
-      return callback coreComponents if err
-      for component in components
-        continue if component.substr(0, 1) is '.'
-        [componentName, componentExtension] = component.split '.'
-        continue unless componentExtension is 'coffee'
-        coreComponents[componentName] = "#{corePath}/#{component}"
-      callback coreComponents
-
-  cachePath: ->
-    path.resolve @baseDir, './.noflo.json'
-
-  writeCache: (callback) ->
-    cacheData =
-      components: {}
-      loaders: []
-
-    loaders = @componentLoaders or []
-    cacheData.loaders = loaders.map (lPath) =>
-      path.relative @baseDir, lPath
-
-    for name, cPath of @components
-      continue unless typeof cPath is 'string'
-      cacheData.components[name] = path.relative @baseDir, cPath
-
-    filePath = @cachePath()
-    fs.writeFile filePath, JSON.stringify(cacheData, null, 2),
+  writeCache: (options, modules, callback) ->
+    filePath = path.resolve @baseDir, options.manifest
+    fs.writeFile filePath, JSON.stringify(modules, null, 2),
       encoding: 'utf-8'
     , callback
 
-  readCache: (callback) ->
-    filePath = @cachePath()
-    fs.readFile filePath,
-      encoding: 'utf-8'
-    , (err, cached) =>
-      return callback err if err
-      return callback new Error 'No cached components found' unless cached
-      try
-        cacheData = JSON.parse cached
-      catch e
-        callback e
-      return callback new Error 'No components in cache' unless cacheData.components
-      @components = {}
-      for name, cPath of cacheData.components
-        @components[name] = path.resolve @baseDir, cPath
-      unless cacheData.loaders?.length
-        callback null
-        return
-      done = _.after cacheData.loaders.length, ->
-        callback null
-      cacheData.loaders.forEach (loaderPath) =>
-        loader = require path.resolve @baseDir, loaderPath
-        @registerLoader loader, done
+  readCache: (options, callback) ->
+    options.discover = false
+    manifest.load.load @baseDir, options, callback
+
+  prepareManifestOptions: ->
+    options = {}
+    options.runtimes = @options.runtimes or []
+    options.runtimes.push 'noflo' if options.runtimes.indexOf('noflo') is -1
+    options.recursive = if typeof @options.recursive is 'undefined' then true else @options.recursive
+    options.manifest = 'fbp.json' unless options.manifest
+    options
+
+  readModules: (modules) ->
+    compatible = modules.filter (m) -> m.runtime in ['noflo', 'noflo-nodejs']
+    for m in compatible
+      @libraryIcons[m.name] = m.icon if m.icon
+      for c in m.components
+        @components["#{m.name}/#{c.name}"] = path.resolve @baseDir, c.path
+
+    # Inject subgraph component
+    @components.Graph = path.resolve __dirname, '../../components/Graph'
 
   listComponents: (callback) ->
     if @processing
@@ -150,56 +59,31 @@ class ComponentLoader extends loader.ComponentLoader
     @ready = false
     @processing = true
 
+    manifestOptions = @prepareManifestOptions()
+    @components = {}
+
     if @options.cache and not @failedCache
-      @readCache (err) =>
+      @readCache manifestOptions, (err, modules) =>
         if err
           @failedCache = true
           @processing = false
           @listComponents callback
           return
+        @readModules modules
         @ready = true
         @processing = false
         @emit 'ready', true
         callback @components if callback
       return
 
-    @components = {}
-
-    done = _.after 2, =>
+    manifest.list.list @baseDir, manifestOptions, (err, modules) =>
+      @readModules modules
       @ready = true
       @processing = false
       @emit 'ready', true
-      unless @options.cache
-        callback @components if callback
-        return
-      @writeCache =>
-        callback @components if callback
-      return
-
-    @getCoreComponents (coreComponents) =>
-      @components[name] = cPath for name, cPath of coreComponents
-      done()
-
-    reader @baseDir, (err, data) =>
-      return done() if err
-      @getModuleComponents data, (components) =>
-        @components[name] = cPath for name, cPath of components
-        done()
-
-  getPackagePath: (packageId, callback) ->
-    found = null
-    seen = []
-    find = (packageData) ->
-      return if seen.indexOf(packageData.name) isnt -1
-      seen.push packageData.name
-      if packageData.name is packageId
-        found = path.resolve packageData.realPath, './package.json'
-        return
-      _.each packageData.dependencies, find
-    reader @baseDir, (err, data) ->
-      return callback err if err
-      find data
-      return callback null, found
+      return callback @components unless @options.cache
+      @writeCache manifestOptions, modules, =>
+        callback @components
 
   setSource: (packageId, name, source, language, callback) ->
     unless @ready
@@ -278,44 +162,5 @@ class ComponentLoader extends loader.ComponentLoader
         library: nameParts[0]
         language: utils.guessLanguageFromFilename component
         code: code
-
-  readPackage: (packageId, callback) ->
-    @getPackagePath packageId, (err, packageFile) =>
-      return callback err if err
-      return callback new Error 'no package found' unless packageFile
-      @readPackageFile packageFile, callback
-
-  readPackageFile: (packageFile, callback) ->
-    fs.readFile packageFile, 'utf-8', (err, packageData) ->
-      return callback err if err
-      data = JSON.parse packageData
-      data.realPath = path.dirname packageFile
-      callback null, data
-
-  writePackage: (packageId, data, callback) ->
-    @getPackagePath packageId, (err, packageFile) ->
-      return callback err if err
-      return callback new Error 'no package found' unless packageFile
-      delete data.realPath if data.realPath
-      packageData = JSON.stringify data, null, 2
-      fs.writeFile packageFile, packageData, callback
-
-  registerComponentToDisk: (packageId, name, cPath, callback = ->) ->
-    @readPackage packageId, (err, packageData) =>
-      return callback err if err
-      packageData.noflo = {} unless packageData.noflo
-      packageData.noflo.components = {} unless packageData.noflo.components
-      packageData.noflo.components[name] = cPath
-      @clear()
-      @writePackage packageId, packageData, callback
-
-  registerGraphToDisk: (packageId, name, cPath, callback = ->) ->
-    @readPackage packageId, (err, packageData) =>
-      return callback err if err
-      packageData.noflo = {} unless packageData.noflo
-      packageData.noflo.graphs = {} unless packageData.noflo.graphs
-      packageData.noflo.graphs[name] = cPath
-      @clear()
-      @writePackage packageId, packageData, callback
 
 exports.ComponentLoader = ComponentLoader

--- a/src/lib/nodejs/ComponentLoader.coffee
+++ b/src/lib/nodejs/ComponentLoader.coffee
@@ -76,7 +76,6 @@ class ComponentLoader extends loader.ComponentLoader
     @processing = true
 
     manifestOptions = @prepareManifestOptions()
-    @components = {}
 
     if @options.cache and not @failedCache
       @readCache manifestOptions, (err, modules) =>
@@ -85,6 +84,7 @@ class ComponentLoader extends loader.ComponentLoader
           @processing = false
           @listComponents callback
           return
+        @components = {}
         @readModules modules, (err) =>
           @ready = true
           @processing = false
@@ -92,6 +92,7 @@ class ComponentLoader extends loader.ComponentLoader
           callback @components if callback
       return
 
+    @components = {}
     manifest.list.list @baseDir, manifestOptions, (err, modules) =>
       @readModules modules, (err) =>
         @ready = true


### PR DESCRIPTION
This PR will migrate component discovery to be based on the [FBP Manifest](https://github.com/flowbased/fbp-manifest) instead of NPM traversal.

Will fix #367

Bonus items:

* Faster builds (30-40% faster on Travis)
* Should fix Windows builds, except for #408