### PR TITLE
Convert all IP handling to IP objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ NoFlo ChangeLog
 * Switched component discovery and caching from `read-installed` to [FBP manifest](https://github.com/flowbased/fbp-manifest). `fbp.json` files can be generated using `noflo-cache-preheat`.
 * Component Loader `listComponents` can now return errors as first callback argument
 * Control ports don't receive bracket IPs, only data
+* NoFlo's InternalSocket now always handles information packets as IP Objects, with conversion to/from legacy packet events done automatically. Use `socket.on('ip', function (ip) {})` to receive IP object
 
 ## 0.6.1 (March 30th 2016)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ NoFlo ChangeLog
 * Switched component discovery and caching from `read-installed` to [FBP manifest](https://github.com/flowbased/fbp-manifest). `fbp.json` files can be generated using `noflo-cache-preheat`.
 * Component Loader `listComponents` can now return errors as first callback argument
 
-## 0.6.1 (March 20th 2016)
+## 0.6.1 (March 30th 2016)
 
 * NoFlo's IP Objects are now available via `noflo.IP`
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Read more at <http://noflojs.org/>.
 
 ## Suitability
 
-NoFlo is not a web framework or a UI toolkit. It is a way to coordinate and reorganize data flow in any JavaScript application. As such, it can be used for whatever purpose JavaScript can be used for. We know of NoFlo being used for anything from building [web servers](https://thegrid.io) and build tools, to coordinating events inside [GUI applications](https://flowhub.io), [driving](http://meemoo.org/blog/2015-01-14-turtle-power-to-the-people/) [robots](http://bergie.iki.fi/blog/noflo-ardrone/), or building Internet-connected [art installations](http://bergie.iki.fi/blog/ingress-table/).
+NoFlo is not a web framework or a UI toolkit. It is a way to coordinate and reorganize data flow in any JavaScript application. As such, it can be used for whatever purpose JavaScript can be used for. We know of NoFlo being used for anything from building [web servers](https://thegrid.io) and build tools, to coordinating events inside [GUI applications](https://flowhub.io), [driving](http://meemoo.org/blog/2015-01-14-turtle-power-to-the-people) [robots](http://bergie.iki.fi/blog/noflo-ardrone/), or building Internet-connected [art installations](http://bergie.iki.fi/blog/ingress-table/).
 
 ## Tools and ecosystem
 

--- a/spec/Component.coffee
+++ b/spec/Component.coffee
@@ -209,7 +209,7 @@ describe 'Component', ->
       chai.expect(c.started).to.equal(false)
       chai.expect(c.isStarted()).to.equal(false)
 
-  describe '-based IPs', ->
+  describe 'with object-based IPs', ->
 
     it 'should speak IP objects', (done) ->
       c = new component.Component

--- a/spec/Component.coffee
+++ b/spec/Component.coffee
@@ -209,7 +209,7 @@ describe 'Component', ->
       chai.expect(c.started).to.equal(false)
       chai.expect(c.isStarted()).to.equal(false)
 
-  describe 'with object-based IPs', ->
+  describe '-based IPs', ->
 
     it 'should speak IP objects', (done) ->
       c = new component.Component
@@ -233,7 +233,7 @@ describe 'Component', ->
       s1 = new socket.InternalSocket
       s2 = new socket.InternalSocket
 
-      s2.on 'data', (ip) ->
+      s2.on 'ip', (ip) ->
         chai.expect(ip).to.be.an 'object'
         chai.expect(ip.type).to.equal 'data'
         chai.expect(ip.groups).to.be.an 'array'
@@ -295,7 +295,7 @@ describe 'Component', ->
       s2 = new socket.InternalSocket
       s3 = new socket.InternalSocket
 
-      s3.on 'data', (ip) ->
+      s3.on 'ip', (ip) ->
         chai.expect(ip).to.be.an 'object'
         chai.expect(ip.type).to.equal 'data'
         chai.expect(ip.data).to.equal '<p><em>Hello</em>, <strong>World!</strong></p>'
@@ -343,7 +343,7 @@ describe 'Component', ->
       c.outPorts.baz.attach sout1
 
       count = 0
-      sout1.on 'data', (ip) ->
+      sout1.on 'ip', (ip) ->
         count++
         if count is 1
           chai.expect(hadIPs).to.eql ['foo']
@@ -373,7 +373,7 @@ describe 'Component', ->
       c.outPorts.baz.attach sout1
 
       count = 0
-      sout1.on 'data', (ip) ->
+      sout1.on 'ip', (ip) ->
         count++
         if count is 1
           chai.expect(triggered).to.eql ['bar']
@@ -409,7 +409,7 @@ describe 'Component', ->
       c.inPorts.bar.attach sin2
       c.outPorts.baz.attach sout1
 
-      sout1.once 'data', (ip) ->
+      sout1.once 'ip', (ip) ->
         chai.expect(ip).to.be.an 'object'
         chai.expect(ip.type).to.equal 'data'
         chai.expect(ip.data.foo).to.equal 'foo'
@@ -444,7 +444,7 @@ describe 'Component', ->
       c.inPorts.bar.attach sin2
       c.outPorts.baz.attach sout1
 
-      sout1.once 'data', (ip) ->
+      sout1.once 'ip', (ip) ->
         chai.expect(ip).to.be.an 'object'
         chai.expect(ip.type).to.equal 'data'
         chai.expect(ip.data.foo).to.equal 'foo'
@@ -478,12 +478,12 @@ describe 'Component', ->
       c.inPorts.bar.attach sin2
       c.outPorts.baz.attach sout1
 
-      sout1.once 'data', (ip) ->
+      sout1.once 'ip', (ip) ->
         chai.expect(ip).to.be.an 'object'
         chai.expect(ip.type).to.equal 'data'
         chai.expect(ip.data.foo).to.equal 'foo'
         chai.expect(ip.data.bar).to.equal 'bar'
-        sout1.once 'data', (ip) ->
+        sout1.once 'ip', (ip) ->
           chai.expect(ip).to.be.an 'object'
           chai.expect(ip.type).to.equal 'data'
           chai.expect(ip.data.foo).to.equal 'boo'
@@ -516,12 +516,12 @@ describe 'Component', ->
       c.inPorts.bar.attach sin2
       c.outPorts.baz.attach sout1
 
-      sout1.once 'data', (ip) ->
+      sout1.once 'ip', (ip) ->
         chai.expect(ip).to.be.an 'object'
         chai.expect(ip.type).to.equal 'data'
         chai.expect(ip.scope).to.equal '1'
         chai.expect(ip.data).to.equal 'Josh and Laura'
-        sout1.once 'data', (ip) ->
+        sout1.once 'ip', (ip) ->
           chai.expect(ip).to.be.an 'object'
           chai.expect(ip.type).to.equal 'data'
           chai.expect(ip.scope).to.equal '2'
@@ -547,7 +547,7 @@ describe 'Component', ->
       c.inPorts.foo.attach sin1
       c.outPorts.baz.attach sout1
 
-      sout1.once 'data', (ip) ->
+      sout1.once 'ip', (ip) ->
         chai.expect(ip).to.be.an 'object'
         chai.expect(ip.type).to.equal 'data'
         chai.expect(ip.scope).to.equal 'baz'
@@ -583,7 +583,7 @@ describe 'Component', ->
         { delay: 10, msg: "four" }
       ]
 
-      sout1.on 'data', (ip) ->
+      sout1.on 'ip', (ip) ->
         chai.expect(ip.data).to.eql sample.shift()
         done() if sample.length is 0
 
@@ -619,7 +619,7 @@ describe 'Component', ->
       ]
 
       count = 0
-      sout1.on 'data', (ip) ->
+      sout1.on 'ip', (ip) ->
         count++
         switch count
           when 1 then src = sample[1]
@@ -700,7 +700,7 @@ describe 'Component', ->
           chai.expect(packet.scope).to.equal 'some-scope'
           output.sendDone new Error 'Should fail'
 
-      sout1.on 'data', (ip) ->
+      sout1.on 'ip', (ip) ->
         chai.expect(ip).to.be.an 'object'
         chai.expect(ip.data).to.be.an.instanceOf Error
         chai.expect(ip.scope).to.equal 'some-scope'
@@ -738,7 +738,7 @@ describe 'Component', ->
       actual = []
       count = 0
 
-      sout1.on 'data', (ip) ->
+      sout1.on 'ip', (ip) ->
         count++
         chai.expect(ip).to.be.an 'object'
         chai.expect(ip.scope).to.equal 'some-scope'
@@ -808,9 +808,9 @@ describe 'Component', ->
         done()
 
       it 'should fail on wrong input', (done) ->
-        sout1.once 'data', (ip) ->
+        sout1.once 'ip', (ip) ->
           done new Error 'Unexpected baz'
-        sout2.once 'data', (ip) ->
+        sout2.once 'ip', (ip) ->
           chai.expect(ip).to.be.an 'object'
           chai.expect(ip.data).to.be.an.error
           chai.expect(ip.data.message).to.contain 'Bar'
@@ -834,7 +834,7 @@ describe 'Component', ->
         ]
         actual = []
         count = 0
-        sout1.on 'data', (ip) ->
+        sout1.on 'ip', (ip) ->
           count++
           switch ip.type
             when 'openBracket'
@@ -846,7 +846,7 @@ describe 'Component', ->
           if count is 6
             chai.expect(actual).to.eql expected
             done()
-        sout2.once 'data', (ip) ->
+        sout2.once 'ip', (ip) ->
           done ip.data
 
         for item in sample

--- a/spec/Component.coffee
+++ b/spec/Component.coffee
@@ -516,12 +516,12 @@ describe 'Component', ->
       c.inPorts.bar.attach sin2
       c.outPorts.baz.attach sout1
 
-      sout1.once 'data', (ip) ->
+      sout1.once 'ip', (ip) ->
         chai.expect(ip).to.be.an 'object'
         chai.expect(ip.type).to.equal 'data'
         chai.expect(ip.data.foo).to.equal 'foo'
         chai.expect(ip.data.bar).to.equal 'bar'
-        sout1.once 'data', (ip) ->
+        sout1.once 'ip', (ip) ->
           chai.expect(ip).to.be.an 'object'
           chai.expect(ip.type).to.equal 'data'
           chai.expect(ip.data.foo).to.equal 'boo'
@@ -529,7 +529,9 @@ describe 'Component', ->
           done()
 
       sin1.post new IP 'data', 'foo'
-      sin2.send new IP 'data', 'bar'
+      sin2.post new IP 'openBracket'
+      sin2.post new IP 'data', 'bar'
+      sin2.post new IP 'closeBracket'
       sin1.post new IP 'data', 'boo'
 
     it 'should isolate packets with different scopes', (done) ->

--- a/spec/ComponentExample.coffee
+++ b/spec/ComponentExample.coffee
@@ -42,9 +42,9 @@ describe 'MergeObjects component', ->
     done()
 
   it 'should not trigger if input is not complete', (done) ->
-    sout1.once 'data', (ip) ->
+    sout1.once 'ip', (ip) ->
       done new Error "Premature result"
-    sout2.once 'data', (ip) ->
+    sout2.once 'ip', (ip) ->
       done new Error "Premature error"
 
     sin1.post new IP 'data', obj1
@@ -53,7 +53,7 @@ describe 'MergeObjects component', ->
     setTimeout done, 10
 
   it 'should merge objects when input is complete', (done) ->
-    sout1.once 'data', (ip) ->
+    sout1.once 'ip', (ip) ->
       chai.expect(ip).to.be.an 'object'
       chai.expect(ip.type).to.equal 'data'
       chai.expect(ip.data).to.be.an 'object'
@@ -61,13 +61,13 @@ describe 'MergeObjects component', ->
       chai.expect(ip.data.title).to.equal obj2.title
       chai.expect(ip.data.age).to.equal obj1.age
       done()
-    sout2.once 'data', (ip) ->
+    sout2.once 'ip', (ip) ->
       done ip
 
     sin3.post new IP 'data', false
 
   it 'should obey the overwrite control', (done) ->
-    sout1.once 'data', (ip) ->
+    sout1.once 'ip', (ip) ->
       chai.expect(ip).to.be.an 'object'
       chai.expect(ip.type).to.equal 'data'
       chai.expect(ip.data).to.be.an 'object'
@@ -75,7 +75,7 @@ describe 'MergeObjects component', ->
       chai.expect(ip.data.title).to.equal obj2.title
       chai.expect(ip.data.age).to.equal obj2.age
       done()
-    sout2.once 'data', (ip) ->
+    sout2.once 'ip', (ip) ->
       done ip
 
     sin3.post new IP 'data', true

--- a/spec/OutPort.coffee
+++ b/spec/OutPort.coffee
@@ -141,7 +141,7 @@ describe 'Outport Port', ->
         'closeBracket'
       ]
       count = 0
-      s1.on 'data', (data) ->
+      s1.on 'ip', (data) ->
         count++
         chai.expect(data).to.be.an 'object'
         chai.expect(data.type).to.equal expectedEvents.shift()
@@ -164,15 +164,15 @@ describe 'Outport Port', ->
           boo: 'baz'
         func: -> this.foo = 456
 
-      s1.on 'data', (data) ->
+      s1.on 'ip', (data) ->
         chai.expect(data).to.be.an 'object'
         chai.expect(data.data).to.equal obj
         chai.expect(data.data.func).to.be.a 'function'
-        s2.on 'data', (data) ->
+        s2.on 'ip', (data) ->
           chai.expect(data).to.be.an 'object'
           chai.expect(data.data).to.equal obj
           chai.expect(data.data.func).to.be.a 'function'
-          s3.on 'data', (data) ->
+          s3.on 'ip', (data) ->
             chai.expect(data).to.be.an 'object'
             chai.expect(data.data).to.equal obj
             chai.expect(data.data.func).to.be.a 'function'
@@ -193,18 +193,18 @@ describe 'Outport Port', ->
           boo: 'baz'
         func: -> this.foo = 456
 
-      s1.on 'data', (data) ->
+      s1.on 'ip', (data) ->
         chai.expect(data).to.be.an 'object'
         # First send is non-cloning
         chai.expect(data.data).to.equal obj
         chai.expect(data.data.func).to.be.a 'function'
-        s2.on 'data', (data) ->
+        s2.on 'ip', (data) ->
           chai.expect(data).to.be.an 'object'
           chai.expect(data.data).to.not.equal obj
           chai.expect(data.data.foo).to.equal obj.foo
           chai.expect(data.data.bar).to.eql obj.bar
           chai.expect(data.data.func).to.be.undefined
-          s3.on 'data', (data) ->
+          s3.on 'ip', (data) ->
             chai.expect(data).to.be.an 'object'
             chai.expect(data.data).to.not.equal obj
             chai.expect(data.data.foo).to.equal obj.foo

--- a/src/lib/IP.coffee
+++ b/src/lib/IP.coffee
@@ -2,11 +2,17 @@
 #     (c) 2016 TheGrid (Rituwall Inc.)
 #     NoFlo may be freely distributed under the MIT license
 module.exports = class IP
+  # Valid IP types
   @types: [
     'data'
     'openBracket'
     'closeBracket'
   ]
+
+  # Detects if an arbitrary value is an IP
+  @isIP: (obj) ->
+    obj and typeof obj is 'object' and
+    obj.type and @types.indexOf(obj.type) > -1
 
   # Creates as new IP object
   # Valid types: 'data', 'openBracket', 'closeBracket'

--- a/src/lib/IP.coffee
+++ b/src/lib/IP.coffee
@@ -16,6 +16,7 @@ module.exports = class IP
     @owner = null # packet owner process
     @clonable = false # cloning safety flag
     @index = null # addressable port index
+    @isIP = true
     for key, val of options
       this[key] = val
 

--- a/src/lib/InPort.coffee
+++ b/src/lib/InPort.coffee
@@ -60,6 +60,26 @@ class InPort extends BasePort
       @handleSocketEvent 'endgroup', group, localId
     socket.on 'disconnect', =>
       @handleSocketEvent 'disconnect', socket, localId
+    socket.on 'ip', (ip) =>
+      @handleIP ip, localId
+
+  handleIP: (ip, id) ->
+    return if @process
+    ip.owner = @nodeInstance
+    ip.index = id
+
+    if ip.scope
+      @scopedBuffer[ip.scope] = [] unless ip.scope of @scopedBuffer
+      buf = @scopedBuffer[ip.scope]
+    else
+      buf = @buffer
+    buf.push ip
+    buf.shift() if @options.control and buf.length > 1
+
+    if @handle
+      @handle ip, @nodeInstance
+
+    @emit 'ip', ip, id
 
   handleSocketEvent: (event, payload, id) ->
     # Handle buffering the old way
@@ -78,72 +98,15 @@ class InPort extends BasePort
         @emit event
       return
 
-    # Prepare IP object
-    if event is 'data' and typeof payload is 'object' and
-    IP.types.indexOf(payload.type) isnt -1
-      ip = payload
-    else
-      # Wrap legacy event
-      switch event
-        when 'connect', 'begingroup'
-          ip = new IP 'openBracket', payload
-        when 'disconnect', 'endgroup'
-          ip = new IP 'closeBracket'
-        else
-          ip = new IP 'data', payload
-
-    ip.owner = @nodeInstance
-    ip.index = id
-
-    # Buffer IP for the component process function
-    unless @process or @handle or @options.buffered
-      if ip.scope
-        @scopedBuffer[ip.scope] = [] unless ip.scope of @scopedBuffer
-        buf = @scopedBuffer[ip.scope]
-      else
-        buf = @buffer
-      buf.push ip
-      buf.shift() if @options.control and buf.length > 1
-
-
-    # Handle IP object
-    if @handle
-      @handle ip, @nodeInstance
-
     if @process
-      # Call the processing function
-      @braceCount = [] unless @braceCount
-      @braceCount[id] = 0 unless @braceCount[id]
-      @isUnwrapped = false
-      if event is 'data' and typeof payload is 'object' and
-      IP.types.indexOf(payload.type) isnt -1
-        # Translate IP object to legacy event
-        switch payload.type
-          when 'openBracket'
-            event = if @braceCount[id] is 0 then 'connect' else 'begingroup'
-            payload = payload.data
-            @braceCount[id]++
-          when 'closeBracket'
-            @braceCount[id]--
-            event = if @braceCount[id] is 0 then 'disconnect' else 'endgroup'
-            payload = null
-          else
-            event = 'data'
-            payload = payload.data
-            @isUnwrapped = true if @braceCount[id] is 0
       if @isAddressable()
-        @process 'connect', null, id, @nodeInstance if @isUnwrapped
         @process event, payload, id, @nodeInstance
-        @process 'disconnect', null, id, @nodeInstance if @isUnwrapped
       else
-        @process 'connect', null, @nodeInstance if @isUnwrapped
         @process event, payload, @nodeInstance
-        @process 'disconnect', null, @nodeInstance if @isUnwrapped
 
     # Emit port event
     return @emit event, payload, id if @isAddressable()
     @emit event, payload
-    @emit 'ip', ip
 
   hasDefault: ->
     return @options.default isnt undefined

--- a/src/lib/InPort.coffee
+++ b/src/lib/InPort.coffee
@@ -65,6 +65,7 @@ class InPort extends BasePort
 
   handleIP: (ip, id) ->
     return if @process
+    return if @options.control and ip.type isnt 'data'
     ip.owner = @nodeInstance
     ip.index = id
 

--- a/src/lib/InternalSocket.coffee
+++ b/src/lib/InternalSocket.coffee
@@ -236,9 +236,9 @@ class InternalSocket extends EventEmitter
 
     # Emit the legacy event
     legacyEvent = @ipToLegacy ip
-    @emitEvent 'connect' if ip.type is 'data' and @braceCount is 0
+    @emitEvent 'connect' if ip.type is 'data' and @braceCount is 0 and not @connected
     @emitEvent legacyEvent.event, legacyEvent.payload
-    @emitEvent 'disconnect' if ip.type is 'data' and @braceCount is 0
+    @emitEvent 'disconnect' if ip.type is 'data' and @braceCount is 0 and @connected
 
 exports.InternalSocket = InternalSocket
 

--- a/src/lib/InternalSocket.coffee
+++ b/src/lib/InternalSocket.coffee
@@ -210,7 +210,7 @@ class InternalSocket extends EventEmitter
       if ip.data is null
         # If we're already connected, no need to connect again
         return if @brackets.length
-      if ip.data
+      else
         if @brackets.length is 0 and autoConnect
           # Connect before sending bracket
           @handleSocketEvent 'connect', null

--- a/src/lib/InternalSocket.coffee
+++ b/src/lib/InternalSocket.coffee
@@ -167,8 +167,6 @@ class InternalSocket extends EventEmitter
 
     # Wrap legacy events into appropriate IP objects
     switch event
-      when 'connect'
-        return new IP 'openBracket', null
       when 'connect', 'begingroup'
         return new IP 'openBracket', payload
       when 'disconnect', 'endgroup'

--- a/src/lib/OutPort.coffee
+++ b/src/lib/OutPort.coffee
@@ -28,10 +28,7 @@ class OutPort extends BasePort
     @checkRequired sockets
     sockets.forEach (socket) ->
       return unless socket
-      return socket.beginGroup group if socket.isConnected()
-      socket.once 'connect', ->
-        socket.beginGroup group
-      socket.connect()
+      return socket.beginGroup group
 
   send: (data, socketId = null) ->
     sockets = @getSockets socketId
@@ -40,10 +37,7 @@ class OutPort extends BasePort
       @cache[socketId] = data
     sockets.forEach (socket) ->
       return unless socket
-      return socket.send data if socket.isConnected()
-      socket.once 'connect', ->
-        socket.send data
-      socket.connect()
+      return socket.send data
 
   endGroup: (socketId = null) ->
     sockets = @getSockets socketId

--- a/src/lib/OutPort.coffee
+++ b/src/lib/OutPort.coffee
@@ -54,8 +54,7 @@ class OutPort extends BasePort
       socket.disconnect()
 
   sendIP: (type, data, options, socketId) ->
-    if typeof type is 'object' and
-    IP.types.indexOf(type).type isnt -1
+    if IP.isIP type
       ip = type
       socketId = ip.index
     else


### PR DESCRIPTION
This PR makes InternalSocket handle all information packets using IP Objects (#356). It adds two-way mappings so legacy methods like `send()` and `begingroup()` convert the payloads to IP objects, and the legacy events are emitted with expected data. To receive the IP object from InternalSocket, listen to the `ip` event.

With these changes it is a lot easier to integrate modern Process API components into existing NoFlo graphs.