### PR TITLE
Fix non-triggering ports and premature input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ NoFlo ChangeLog
 ## 0.7.2 (git master)
 
 * Fixed FBP manifest caching
+* Fixed non-triggering property being applied on triggering ports
+* Fixed `input.getData()` crash on ports which have no packets yet
 
 ## 0.7.1 (March 31st 2016)
 

--- a/spec/Component.coffee
+++ b/spec/Component.coffee
@@ -386,6 +386,35 @@ describe 'Component', ->
       sin1.post new IP 'data', 'first'
       sin2.post new IP 'data', 'second'
 
+    it 'should fetch undefined for premature data', (done) ->
+      c = new component.Component
+        inPorts:
+          foo:
+            datatype: 'string'
+          bar:
+            datatype: 'boolean'
+            triggering: false
+            control: true
+          baz:
+            datatype: 'string'
+            triggering: false
+            control: true
+        process: (input, output) ->
+          return unless input.has 'foo'
+          [foo, bar, baz] = input.getData 'foo', 'bar', 'baz'
+          chai.expect(foo).to.be.a 'string'
+          chai.expect(bar).to.be.undefined
+          chai.expect(baz).to.be.undefined
+          done()
+
+      c.inPorts.foo.attach sin1
+      c.inPorts.bar.attach sin2
+      c.inPorts.baz.attach sin3
+
+      sin1.post new IP 'data', 'AZ'
+      sin2.post new IP 'data', true
+      sin3.post new IP 'data', 'first'
+
     it 'should receive and send complete IP objects', (done) ->
       c = new component.Component
         inPorts:

--- a/src/lib/Component.coffee
+++ b/src/lib/Component.coffee
@@ -31,7 +31,7 @@ class Component extends EventEmitter
       @outPorts = options.outPorts
     else
       @outPorts = new ports.OutPorts options.outPorts
-    
+
     @icon = options.icon if options.icon
     @description = options.description if options.description
     @ordered = options.ordered if 'ordered' of options
@@ -77,9 +77,10 @@ class Component extends EventEmitter
       throw new Error "Component ports must be defined before process function"
     @handle = handle
     for name, port of @inPorts.ports
-      port.name = name unless port.name
-      port.on 'ip', (ip) =>
-        @handleIP ip, port
+      do (name, port) =>
+        port.name = name unless port.name
+        port.on 'ip', (ip) =>
+          @handleIP ip, port
     @
 
   handleIP: (ip, port) ->
@@ -117,8 +118,8 @@ class ProcessInput
   getData: ->
     ips = @get.apply this, arguments
     if arguments.length is 1
-      return ips.data
-    (ip.data for ip in ips)
+      return ips?.data ? undefined
+    (ip?.data ? undefined for ip in ips)
 
 class ProcessOutput
   constructor: (@ports, @ip, @nodeInstance, @result) ->


### PR DESCRIPTION
Non-triggering ports prevented `process` function from being called in some cases because the loop over ports needed a `do` wrapper.

Also, `input.getData()` should return `undefined` for ports that have no data yet instead of crashing.