### PR TITLE
Clean up network lifecycle

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ NoFlo ChangeLog
 
 * Fixed error handling on broken FBP manifest data
 * Fixed network start callback when there are no defaults in a graph
+* Network uptime is now calculated from the first `start` event, not from initialization
 
 ## 0.7.2 (April 1st 2016)
 

--- a/spec/Network.coffee
+++ b/spec/Network.coffee
@@ -451,5 +451,7 @@ describe 'NoFlo Network', ->
         nw.once 'end', ->
           chai.expect(called).to.equal 10001
           done()
-        nw.connect ->
-          nw.start()
+        nw.connect (err) ->
+          return done err if err
+          nw.start (err) ->
+            return done err if err

--- a/spec/Network.coffee
+++ b/spec/Network.coffee
@@ -154,7 +154,8 @@ describe 'NoFlo Network', ->
       g.addInitial 'Foo', 'Merge', 'in'
 
       chai.expect(n.initials).not.to.be.empty
-      n.start()
+      n.start (err) ->
+        return done err if err
 
     it 'should have started in debug mode', ->
       chai.expect(n.debug).to.equal true

--- a/src/lib/Network.coffee
+++ b/src/lib/Network.coffee
@@ -67,7 +67,7 @@ class Network extends EventEmitter
     # As most NoFlo networks are long-running processes, the
     # network coordinator marks down the start-up time. This
     # way we can calculate the uptime of the network.
-    @startupDate = new Date()
+    @startupDate = null
 
     # Initialize a Component Loader for the network
     if graph.componentLoader

--- a/src/lib/Network.coffee
+++ b/src/lib/Network.coffee
@@ -77,7 +77,9 @@ class Network extends EventEmitter
 
   # The uptime of the network is the current time minus the start-up
   # time, in seconds.
-  uptime: -> new Date() - @startupDate
+  uptime: ->
+    return 0 unless @startupDate
+    new Date() - @startupDate
 
   # Emit a 'start' event on the first connection, and 'end' event when
   # last connection has been closed

--- a/src/lib/Network.coffee
+++ b/src/lib/Network.coffee
@@ -6,8 +6,9 @@ _ = require "underscore"
 internalSocket = require "./InternalSocket"
 graph = require "./Graph"
 {EventEmitter} = require 'events'
+platform = require './Platform'
 
-unless require('./Platform').isBrowser()
+unless platform.isBrowser()
   componentLoader = require "./nodejs/ComponentLoader"
 else
   componentLoader = require './ComponentLoader'
@@ -55,7 +56,7 @@ class Network extends EventEmitter
 
     # On Node.js we default the baseDir for component loading to
     # the current working directory
-    if typeof process isnt 'undefined' and process.execPath and process.execPath.indexOf('node') isnt -1
+    unless platform.isBrowser()
       @baseDir = graph.baseDir or process.cwd()
     # On browser we default the baseDir to the Component loading
     # root


### PR DESCRIPTION
This one ensures network start event is sent when network is started regardless of whether there are IIPs in the graph. Needed for fbp-spec.

Preliminary work for #370