### PR TITLE
Remove dropEmptyBrackets option

### DIFF
--- a/spec/Component.coffee
+++ b/spec/Component.coffee
@@ -864,6 +864,7 @@ describe 'Component', ->
         done() if count is 4
 
       sout2.on 'ip', (ip) ->
+        return if ip.type isnt 'data'
         console.log 'Unexpected error', ip
         done ip.data
 

--- a/src/lib/Component.coffee
+++ b/src/lib/Component.coffee
@@ -38,12 +38,9 @@ class Component extends EventEmitter
     @activateOnInput = options.activateOnInput ? true
     @forwardBrackets = in: ['out', 'error']
     @bracketCounter = {}
-    @dropEmptyBrackets = ['error']
 
     if 'forwardBrackets' of options
       @forwardBrackets = options.forwardBrackets
-    if 'dropEmptyBrackets' of options
-      @dropEmptyBrackets = options.dropEmptyBrackets
 
     if typeof options.process is 'function'
       @process options.process
@@ -91,10 +88,6 @@ class Component extends EventEmitter
       else
         @forwardBrackets[inPort] = tmp
         @bracketCounter[inPort] = 0
-    tmp = []
-    for outPort in @dropEmptyBrackets
-      tmp.push outPort if outPort of @outPorts.ports
-    @dropEmptyBrackets = tmp
 
   # Sets process handler function
   process: (handle) ->
@@ -120,7 +113,7 @@ class Component extends EventEmitter
     (ip.type is 'openBracket' or ip.type is 'closeBracket')
       # Bracket forwarding
       outputEntry =
-        __resolved: ip.type is 'closeBracket' or not @dropEmptyBrackets.length
+        __resolved: true
         __forwarded: true
         __type: ip.type
         __scope: ip.scope
@@ -128,28 +121,6 @@ class Component extends EventEmitter
         outputEntry[outPort] = [] unless outPort of outputEntry
         outputEntry[outPort].push ip
       port.buffer.pop()
-      # Drop empty brackets if needed
-      if ip.type is 'closeBracket' and @dropEmptyBrackets.length
-        haveData = []
-        for i in [@outputQ.length - 1..0]
-          entry = @outputQ[i]
-          if '__forwarded' of entry
-            if entry.__type is 'openBracket' and not entry.__resolved and
-            entry.__scope is ip.scope
-              for port, ips of entry
-                if haveData.indexOf(port) is -1 and
-                @dropEmptyBrackets.indexOf(port) isnt -1
-                  delete entry[port]
-                  delete outputEntry[port]
-              entry.__resolved = true
-              break
-          else
-            for port, ips of entry
-              continue if port.indexOf('__') is 0 or haveData.indexOf(port) >= 0
-              for _ip in ips
-                if _ip.scope is ip.scope
-                  haveData.push port
-                  break
       @outputQ.push outputEntry
       @processOutputQueue()
       return


### PR DESCRIPTION
`dropEmptyBrackets` doesn't work correctly for async components, see #444.

There's probably a side effect of merging this though: once merged, `error` ports will start producing empty brackets for every successful run (if brackets are present on `in`, of course), so apps need to be modified to ignore them.