### PR TITLE
Add deprecation warnings

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ NoFlo ChangeLog
   - noflo.ArrayPort: should be ported to noflo.In/OutPort with `addressable: true`
   - noflo.Port: should be ported to noflo.In/OutPort
   - Calling Network.start or Network.stop without a callback
+  - Additionally component.io builds warn about deprecation in favor of webpack
 
 ## 0.7.8 (June 10th 2016)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,11 @@ NoFlo ChangeLog
 
 * Added callback for `Network.stop`
 * Outmost brackets are no longer automatically converted to `connect` and `disconnect` events. Instead, `connect` and `disconnect` are injected as needed, but only for subscribers of the legacy events
+* Added deprecation warnings for APIs that will be removed by NoFlo 1.0. These can be made fatal by setting the `NOFLO_FATAL_DEPRECATED` environment variable. These include:
+  - noflo.AsyncComponent: should be ported to Process API
+  - noflo.ArrayPort: should be ported to noflo.In/OutPort with `addressable: true`
+  - noflo.Port: should be ported to noflo.In/OutPort
+  - Calling Network.start or Network.stop without a callback
 
 ## 0.7.8 (June 10th 2016)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ NoFlo ChangeLog
 * Outmost brackets are no longer automatically converted to `connect` and `disconnect` events. Instead, `connect` and `disconnect` are injected as needed, but only for subscribers of the legacy events
 * Added deprecation warnings for APIs that will be removed by NoFlo 1.0. These can be made fatal by setting the `NOFLO_FATAL_DEPRECATED` environment variable. These include:
   - noflo.AsyncComponent: should be ported to Process API
+  - noflo.helpers.MapComponent: should be ported to Process API
   - noflo.ArrayPort: should be ported to noflo.In/OutPort with `addressable: true`
   - noflo.Port: should be ported to noflo.In/OutPort
   - Calling Network.start or Network.stop without a callback

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,15 +6,15 @@ NoFlo ChangeLog
 * Added callback for `Network.stop`
 * Outmost brackets are no longer automatically converted to `connect` and `disconnect` events. Instead, `connect` and `disconnect` are injected as needed, but only for subscribers of the legacy events
 * Added deprecation warnings for APIs that will be removed by NoFlo 1.0. These can be made fatal by setting the `NOFLO_FATAL_DEPRECATED` environment variable. These include:
-  - noflo.AsyncComponent: should be ported to Process API
-  - noflo.helpers.MapComponent: should be ported to Process API
-  - noflo.ArrayPort: should be ported to noflo.In/OutPort with `addressable: true`
-  - noflo.Port: should be ported to noflo.In/OutPort
-  - Calling Network.start or Network.stop without a callback
-  - noflo.InPort process option: should be ported to Process API or use the handle option
-  - noflo.InPort receive method: replaced by the get method
-  - noflo.InPort contains method: replaced by the has method
-  - Additionally component.io builds warn about deprecation in favor of webpack
+  - `noflo.AsyncComponent`: should be ported to Process API
+  - `noflo.helpers.MapComponent`: should be ported to Process API
+  - `noflo.ArrayPort`: should be ported to noflo.In/OutPort with `addressable: true`
+  - `noflo.Port`: should be ported to noflo.In/OutPort
+  - Calling `Network.start` or `Network.stop` without a callback
+  - `noflo.InPort` `process` option: should be ported to Process API or use the `handle` option
+  - `noflo.InPort` `receive` method: replaced by the `get` method
+  - `noflo.InPort` `contains` method: replaced by the `has` method
+  - Additionally [component.io](https://github.com/componentjs/component) builds warn about deprecation in favor of [webpack](http://webpack.github.io/) with helpful automation available in [grunt-noflo-browser](https://www.npmjs.com/package/grunt-noflo-browser)
 
 ## 0.7.8 (June 10th 2016)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@ NoFlo ChangeLog
   - noflo.ArrayPort: should be ported to noflo.In/OutPort with `addressable: true`
   - noflo.Port: should be ported to noflo.In/OutPort
   - Calling Network.start or Network.stop without a callback
+  - noflo.InPort process option: should be ported to Process API or use the handle option
+  - noflo.InPort receive method: replaced by the get method
+  - noflo.InPort contains method: replaced by the has method
   - Additionally component.io builds warn about deprecation in favor of webpack
 
 ## 0.7.8 (June 10th 2016)

--- a/src/lib/ArrayPort.coffee
+++ b/src/lib/ArrayPort.coffee
@@ -6,9 +6,11 @@
 # ArrayPorts are similar to regular ports except that they're able to handle multiple
 # connections and even address them separately.
 port = require "./Port"
+platform = require './Platform'
 
 class ArrayPort extends port.Port
   constructor: (@type) ->
+    platform.deprecated 'noflo.ArrayPort is deprecated. Please port to noflo.InPort/noflo.OutPort and use addressable: true'
     super @type
 
   attach: (socket, socketId = null) ->

--- a/src/lib/AsyncComponent.coffee
+++ b/src/lib/AsyncComponent.coffee
@@ -7,10 +7,13 @@
 # throttling.
 port = require "./Port"
 component = require "./Component"
+platform = require './Platform'
 
 class AsyncComponent extends component.Component
 
   constructor: (@inPortName="in", @outPortName="out", @errPortName="error") ->
+    platform.deprecated 'noflo.AsyncComponent is deprecated. Please port to Process API'
+
     unless @inPorts[@inPortName]
       throw new Error "no inPort named '#{@inPortName}'"
     unless @outPorts[@outPortName]

--- a/src/lib/Helpers.coffee
+++ b/src/lib/Helpers.coffee
@@ -5,6 +5,7 @@ _ = require 'underscore'
 StreamSender = require('./Streams').StreamSender
 StreamReceiver = require('./Streams').StreamReceiver
 InternalSocket = require './InternalSocket'
+platform = require './Platform'
 
 isArray = (obj) ->
   return Array.isArray(obj) if Array.isArray
@@ -13,6 +14,7 @@ isArray = (obj) ->
 # MapComponent maps a single inport to a single outport, forwarding all
 # groups from in to out and calling `func` on each incoming packet
 exports.MapComponent = (component, func, config) ->
+  platform.deprecated 'noflo.helpers.MapComponent is deprecated. Please port Process API'
   config = {} unless config
   config.inPort = 'in' unless config.inPort
   config.outPort = 'out' unless config.outPort

--- a/src/lib/InPort.coffee
+++ b/src/lib/InPort.coffee
@@ -5,6 +5,7 @@
 # Input Port (inport) implementation for NoFlo components
 BasePort = require './BasePort'
 IP = require './IP'
+platform = require './Platform'
 
 class InPort extends BasePort
   constructor: (options, process) ->
@@ -25,6 +26,7 @@ class InPort extends BasePort
       delete options.process
 
     if process
+      platform.deprecated 'InPort process callback is deprecated. Please use Process API or the InPort handle option'
       unless typeof process is 'function'
         throw new Error 'process must be a function'
       @process = process
@@ -122,12 +124,14 @@ class InPort extends BasePort
 
   # Returns the next packet in the (legacy) buffer
   receive: ->
+    platform.deprecated 'InPort.receive is deprecated. Use InPort.get instead'
     unless @isBuffered()
       throw new Error 'Receive is only possible on buffered ports'
     @buffer.shift()
 
   # Returns the number of data packets in a (legacy) buffered inport
   contains: ->
+    platform.deprecated 'InPort.contains is deprecated. Use InPort.has instead'
     unless @isBuffered()
       throw new Error 'Contains query is only possible on buffered ports'
     @buffer.filter((packet) -> return true if packet.event is 'data').length

--- a/src/lib/Network.coffee
+++ b/src/lib/Network.coffee
@@ -564,6 +564,7 @@ class Network extends EventEmitter
 
   start: (callback) ->
     unless callback
+      platform.deprecated 'Calling network.start() without callback is deprecated'
       callback = ->
 
     do @stop if @started
@@ -578,6 +579,10 @@ class Network extends EventEmitter
           callback null
 
   stop: (callback) ->
+    unless callback
+      platform.deprecated 'Calling network.stop() without callback is deprecated'
+      callback = ->
+
     # Disconnect all connections
     for connection in @connections
       continue unless connection.isConnected()
@@ -586,7 +591,7 @@ class Network extends EventEmitter
     for id, process of @processes
       process.component.shutdown()
     @setStarted false
-    do callback if callback
+    do callback
 
   setStarted: (started) ->
     return if @started is started

--- a/src/lib/Platform.coffee
+++ b/src/lib/Platform.coffee
@@ -7,3 +7,12 @@ exports.isBrowser = ->
   if typeof process isnt 'undefined' and process.execPath and process.execPath.match /node|iojs/
     return false
   true
+
+exports.warnDeprecated = (message) ->
+  if exports.isBrowser()
+    throw new Error message if window.NOFLO_FATAL_DEPRECATED
+    console.warn message
+    return
+  if process.env.NOFLO_FATAL_DEPRECATED
+    throw new Error message
+  console.warn message

--- a/src/lib/Platform.coffee
+++ b/src/lib/Platform.coffee
@@ -8,7 +8,7 @@ exports.isBrowser = ->
     return false
   true
 
-exports.warnDeprecated = (message) ->
+exports.deprecated = (message) ->
   if exports.isBrowser()
     throw new Error message if window.NOFLO_FATAL_DEPRECATED
     console.warn message

--- a/src/lib/Port.coffee
+++ b/src/lib/Port.coffee
@@ -5,11 +5,13 @@
 #
 # Regular port for NoFlo components.
 {EventEmitter} = require 'events'
+platform = require './Platform'
 
 class Port extends EventEmitter
   description: ''
   required: true
   constructor: (@type) ->
+    platform.deprecated 'noflo.Port is deprecated. Please port to noflo.InPort/noflo.OutPort'
     @type = 'all' unless @type
     @type = 'int' if @type is 'integer'
     @sockets = []

--- a/src/lib/loader/ComponentIo.coffee
+++ b/src/lib/loader/ComponentIo.coffee
@@ -1,5 +1,6 @@
 utils = require '../Utils'
 nofloGraph = require '../Graph'
+platform = require '../Platform'
 
 customLoader =
   checked: []
@@ -59,6 +60,8 @@ customLoader =
       do callback
 
 exports.register = (loader, callback) ->
+  platform.deprecated 'Component.io is deprecated. Please make browser builds using webpack instead. grunt-noflo-browser provides a simple setup for this'
+
   customLoader.checked = []
   # Start discovery from baseDir
   setTimeout ->


### PR DESCRIPTION
For 0.8.0 we should add deprecation warnings to APIs we plan to drop in 1.0.0

Developers can make these warnings fatal by setting the `NOFLO_FATAL_DEPRECATED` env var.