### PR TITLE
Remove direct babel-core dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ NoFlo ChangeLog
 * Added IP object `scope` support to `WirePattern` to make `WirePattern` components more concurrency-friendly
 * Removed `receiveStreams` option from `WirePattern`
 * Graph JSON schema has been moved to https://github.com/flowbased/fbp, and updated with tests.
+* [babel-core](https://www.npmjs.com/package/babel-core) was removed as a dependency. Install separately for projects needing ES6 component support
 
 ## 0.7.8 (June 10th 2016)
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "node": ">=0.6.0"
   },
   "dependencies": {
-    "babel-core": "~6.9.0",
     "coffee-script": "~1.10.0",
     "fbp": "~1.4.0",
     "fbp-manifest": "~0.1.8",


### PR DESCRIPTION
This makes installation size smaller and installs faster. Projects needing ES6 components can still install it as needed.