### PR TITLE
Allow buffer access by index for addressable ports

### DIFF
--- a/src/lib/InPort.coffee
+++ b/src/lib/InPort.coffee
@@ -148,12 +148,17 @@ class InPort extends BasePort
     @buffer.filter((packet) -> return true if packet.event is 'data').length
 
   getBuffer: (scope, idx) ->
+    if @isAddressable()
+      if ip.scope?
+        return undefined unless scope of @scopedBuffer
+        return undefined unless idx of @scopedBuffer[scope]
+        return @scopedBuffer[scope][idx]
+      return undefined unless idx of @indexedBuffer
+      return @indexedBuffer[idx]
     if scope?
       return undefined unless scope of @scopedBuffer
-      buf = @scopedBuffer[scope]
-    else
-      buf = @buffer
-    return buf
+      return @scopedBuffer[scope]
+    return @buffer
 
   # Fetches a packet from the port
   get: (scope, idx) ->

--- a/src/lib/InPort.coffee
+++ b/src/lib/InPort.coffee
@@ -149,7 +149,7 @@ class InPort extends BasePort
 
   getBuffer: (scope, idx) ->
     if @isAddressable()
-      if ip.scope?
+      if scope?
         return undefined unless scope of @scopedBuffer
         return undefined unless idx of @scopedBuffer[scope]
         return @scopedBuffer[scope][idx]


### PR DESCRIPTION
When reading from addressable inports, use `[portname, idx]`

* Convenience method `input.attached('portname')` returns list of attached indexes to a given port
* Input methods `has`, `hasData`, `hasStream`, `get`, `getData`, and `getStream` all allow reading from a given connection index with `[portname, idx]` with addressable inports

So, when reading from non-addressable inport like:

```coffeescript
return unless input.hasData 'foo'
data = input.getData 'foo'
```

The equivalent code for an addressable inport would be:

```coffeescript
return unless input.hasData ['foo', 2]
data = input.getData ['foo', 2]
```

If one wants to read from any connected index with data, you can do that with:

```coffeescript
indexesWithData = input.attached('foo').filter (idx) -> input.hasData ['foo', idx]
return unless indexesWithData.length
data = input.getData ['foo', indexesWithData[0]]
```