### PR TITLE
Fix IP data turned from null to undefined

### DIFF
--- a/src/lib/Component.coffee
+++ b/src/lib/Component.coffee
@@ -604,8 +604,7 @@ class ProcessInput
         packet = @get port
         break unless packet
 
-      packet = packet?.data ? undefined
-      datas.push packet
+      datas.push packet.data
 
     return datas.pop() if args.length is 1
     datas


### PR DESCRIPTION
`input.getData()` was returning `undefined` instead of `null` if `ip.data` is `null`. That was not very type-safe and made some tests in libraries fail.