### PR TITLE
Fix IIPs vs. scope problem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@ NoFlo ChangeLog
 ## 0.8.2 (git master)
 
 * Improved subgraph instantiation error handling
+* Fixed a problem of IIPs not visible to processes when inside an IP scope
 
 ## 0.8.1 (March 2nd 2017)
 

--- a/spec/Scoping.coffee
+++ b/spec/Scoping.coffee
@@ -78,6 +78,29 @@ processMerge = ->
     output.sendDone
       out: "1#{first}:2#{second}:#{c.nodeId}"
 
+# Merge with an addressable port
+processMergeA = ->
+  c = new noflo.Component
+  c.inPorts.add 'in1',
+    datatype: 'string'
+  c.inPorts.add 'in2',
+    datatype: 'string'
+    addressable: true
+  c.outPorts.add 'out',
+    datatype: 'string'
+
+  c.forwardBrackets =
+    'in1': ['out']
+
+  c.process (input, output) ->
+    return unless input.hasData 'in1', ['in2', 0], ['in2', 1]
+    first = input.getData 'in1'
+    second0 = input.getData ['in2', 0]
+    second1 = input.getData ['in2', 1]
+
+    output.sendDone
+      out: "1#{first}:2#{second0}:2#{second1}:#{c.nodeId}"
+
 describe 'Scope isolation', ->
   loader = null
   before (done) ->
@@ -88,6 +111,7 @@ describe 'Scope isolation', ->
       loader.registerComponent 'wirepattern', 'Merge', wirePatternMerge
       loader.registerComponent 'process', 'Async', processAsync
       loader.registerComponent 'process', 'Merge', processMerge
+      loader.registerComponent 'process', 'MergeA', processMergeA
       done()
 
   describe 'with WirePattern sending to Process API', ->
@@ -379,6 +403,62 @@ describe 'Scope isolation', ->
       expected = [
         'x < 1'
         'x DATA 1onePc1:2twoIIP:PcMerge'
+        'x >'
+      ]
+      received = []
+      brackets = []
+
+      out.on 'ip', (ip) ->
+        switch ip.type
+          when 'openBracket'
+            received.push "#{ip.scope} < #{ip.data}"
+            brackets.push ip.data
+          when 'data'
+            received.push "#{ip.scope} DATA #{ip.data}"
+          when 'closeBracket'
+            received.push "#{ip.scope} >"
+            brackets.pop()
+            return if brackets.length
+            chai.expect(received).to.eql expected
+            done()
+
+      in1.post new noflo.IP 'openBracket', 1, scope: 'x'
+      in1.post new noflo.IP 'data', 'one', scope: 'x'
+      in1.post new noflo.IP 'closeBracket', 1, scope: 'x'
+
+  describe 'Process API with IIPs to addressable ports and scopes', ->
+    c = null
+    in1 = null
+    in2 = null
+    out = null
+    before (done) ->
+      fbpData = "
+      INPORT=Pc1.IN:IN1
+      OUTPORT=PcMergeA.OUT:OUT
+      Pc1(process/Async) -> IN1 PcMergeA(process/MergeA)
+      'twoIIP0' -> IN2[0] PcMergeA
+      'twoIIP1' -> IN2[1] PcMergeA
+      "
+      noflo.graph.loadFBP fbpData, (err, g) ->
+        return done err if err
+        loader.registerComponent 'scope', 'MergeIIPA', g
+        loader.load 'scope/MergeIIPA', (err, instance) ->
+          return done err if err
+          c = instance
+          in1 = noflo.internalSocket.createSocket()
+          c.inPorts.in1.attach in1
+          done()
+    beforeEach ->
+      out = noflo.internalSocket.createSocket()
+      c.outPorts.out.attach out
+    afterEach ->
+      c.outPorts.out.detach out
+      out = null
+
+    it 'should forward scopes as expected', (done) ->
+      expected = [
+        'x < 1'
+        'x DATA 1onePc1:2twoIIP0:2twoIIP1:PcMergeA'
         'x >'
       ]
       received = []

--- a/src/lib/Network.coffee
+++ b/src/lib/Network.coffee
@@ -8,6 +8,7 @@ graph = require "fbp-graph"
 platform = require './Platform'
 componentLoader = require './ComponentLoader'
 utils = require './Utils'
+IP = require './IP'
 
 # ## The NoFlo network coordinator
 #
@@ -542,9 +543,8 @@ class Network extends EventEmitter
     do callback
 
   sendInitial: (initial) ->
-    initial.socket.connect()
-    initial.socket.send initial.data
-    initial.socket.disconnect()
+    initial.socket.post new IP 'data', initial.data,
+      initial: true
 
   sendInitials: (callback) ->
     unless callback


### PR DESCRIPTION
The problem is that IIPs have no scope and thus are invisible to processes when dealing with scoped packets arriving at other ports. While one would normally expect IIPs to be visible across scopes.