### PR TITLE
noflo.asCallback

### DIFF
--- a/spec/AsCallback.coffee
+++ b/spec/AsCallback.coffee
@@ -111,9 +111,63 @@ describe 'asCallback interface', ->
       received = 0
       [0..100].forEach (idx) ->
         wrapped idx, (err, out) ->
+          return done err if err
           chai.expect(out).to.equal idx
           received++
           return unless received is 101
+          done()
+    it 'should execute a network with a sequence and provide output sequence', (done) ->
+      sent = [
+        in: 'hello'
+      ,
+        in: 'world'
+      ,
+        in: 'foo'
+      ,
+        in: 'bar'
+      ]
+      expected = sent.map (portmap) ->
+        return res =
+          out: portmap.in
+      wrapped sent, (err, out) ->
+        return done err if err
+        chai.expect(out).to.eql expected
+        done()
+    describe 'with the raw option', ->
+      it 'should execute a network with a sequence and provide output sequence', (done) ->
+        wrappedRaw = noflo.asCallback 'process/Async',
+          loader: loader
+          raw: true
+        sent = [
+          in: new noflo.IP 'openBracket', 'a'
+        ,
+          in: 'hello'
+        ,
+          in: 'world'
+        ,
+          in: new noflo.IP 'closeBracket', 'a'
+        ,
+          in: new noflo.IP 'openBracket', 'b'
+        ,
+          in: 'foo'
+        ,
+          in: 'bar'
+        ,
+          in: new noflo.IP 'closeBracket', 'b'
+        ]
+        wrappedRaw sent, (err, out) ->
+          return done err if err
+          types = out.map (map) -> "#{map.out.type} #{map.out.data}"
+          chai.expect(types).to.eql [
+            'openBracket a'
+            'data hello'
+            'data world'
+            'closeBracket a'
+            'openBracket b'
+            'data foo'
+            'data bar'
+            'closeBracket b'
+          ]
           done()
   describe 'with a component sending an error', ->
     wrapped = null

--- a/spec/AsCallback.coffee
+++ b/spec/AsCallback.coffee
@@ -55,7 +55,7 @@ describe 'asCallback interface', ->
         output.send new noflo.IP 'openBracket', idx
         chars = word.split ''
         output.send new noflo.IP 'data', char for char in chars
-        output.send new noflo.IP 'closeBracket'
+        output.send new noflo.IP 'closeBracket', idx
       output.done()
 
   before (done) ->
@@ -147,3 +147,29 @@ describe 'asCallback interface', ->
           ['t','h','e','r','e']
         ]
         done()
+    describe 'with the raw option', ->
+      it 'should execute network with input map and provide output map with IP objects', (done) ->
+        wrappedRaw = noflo.asCallback 'process/Streamify',
+          loader: loader
+          raw: true
+        wrappedRaw
+          in: 'hello world'
+        , (err, out) ->
+          types = out.out.map (ip) -> "#{ip.type} #{ip.data}"
+          chai.expect(types).to.eql [
+            'openBracket 0'
+            'data h'
+            'data e'
+            'data l'
+            'data l'
+            'data o'
+            'closeBracket 0'
+            'openBracket 1'
+            'data w'
+            'data o'
+            'data r'
+            'data l'
+            'data d'
+            'closeBracket 1'
+          ]
+          done()

--- a/spec/AsCallback.coffee
+++ b/spec/AsCallback.coffee
@@ -107,6 +107,14 @@ describe 'asCallback interface', ->
         return done err if err
         chai.expect(out).to.eql expected
         done()
+    it 'should not mix up simultaneous runs', (done) ->
+      received = 0
+      [0..100].forEach (idx) ->
+        wrapped idx, (err, out) ->
+          chai.expect(out).to.equal idx
+          received++
+          return unless received is 101
+          done()
   describe 'with a component sending an error', ->
     wrapped = null
     before ->

--- a/spec/AsCallback.coffee
+++ b/spec/AsCallback.coffee
@@ -1,0 +1,73 @@
+if typeof process isnt 'undefined' and process.execPath and process.execPath.match /node|iojs/
+  chai = require 'chai' unless chai
+  noflo = require '../src/lib/NoFlo.coffee'
+  path = require 'path'
+  root = path.resolve __dirname, '../'
+  urlPrefix = './'
+else
+  noflo = require 'noflo'
+  root = 'noflo'
+  urlPrefix = '/'
+
+describe 'asCallback interface', ->
+  loader = null
+
+  processAsync = ->
+    c = new noflo.Component
+    c.inPorts.add 'in',
+      datatype: 'string'
+    c.outPorts.add 'out',
+      datatype: 'string'
+
+    c.process (input, output) ->
+      data = input.getData 'in'
+      setTimeout ->
+        output.sendDone data
+      , 1
+
+  before (done) ->
+    loader = new noflo.ComponentLoader root
+    loader.listComponents (err) ->
+      return done err if err
+      loader.registerComponent 'process', 'Async', processAsync
+      done()
+  describe 'with a non-existing component', ->
+    wrapped = null
+    before ->
+      wrapped = noflo.asCallback 'foo/Bar',
+        loader: loader
+    it 'should be able to wrap it', (done) ->
+      chai.expect(wrapped).to.be.a 'function'
+      chai.expect(wrapped.length).to.equal 2
+      done()
+    it 'should fail execution', (done) ->
+      wrapped 1, (err) ->
+        chai.expect(err).to.be.an 'error'
+        done()
+  describe 'with simple asynchronous component', ->
+    wrapped = null
+    before ->
+      wrapped = noflo.asCallback 'process/Async',
+        loader: loader
+    it 'should be able to wrap it', (done) ->
+      chai.expect(wrapped).to.be.a 'function'
+      chai.expect(wrapped.length).to.equal 2
+      done()
+    it 'should execute network with input map and provide output map', (done) ->
+      expected =
+        hello: 'world'
+
+      wrapped
+        in: expected
+      , (err, out) ->
+        return done err if err
+        chai.expect(out.out).to.eql expected
+        done()
+    it 'should execute network with simple input and provide simple output', (done) ->
+      expected =
+        hello: 'world'
+
+      wrapped expected, (err, out) ->
+        return done err if err
+        chai.expect(out).to.eql expected
+        done()

--- a/src/lib/AsCallback.coffee
+++ b/src/lib/AsCallback.coffee
@@ -7,6 +7,8 @@ Graph = require('fbp-graph').Graph
 normalizeOptions = (options, component) ->
   options = {} unless options
   options.name = component unless options.name
+  if options.loader
+    options.baseDir = options.loader.baseDir
   if not options.baseDir and process and process.cwd
     options.baseDir = process.cwd()
   unless options.loader

--- a/src/lib/AsCallback.coffee
+++ b/src/lib/AsCallback.coffee
@@ -1,0 +1,124 @@
+ComponentLoader = require('./ComponentLoader').ComponentLoader
+Network = require('./Network').Network
+internalSocket = require './InternalSocket'
+Graph = require('fbp-graph').Graph
+
+normalizeOptions = (options, component) ->
+  options = {} unless options
+  options.name = component unless options.name
+  if not options.baseDir and process and process.cwd
+    options.baseDir = process.cwd()
+  unless options.loader
+    options.loader = new ComponentLoader options.baseDir
+  options.network = null
+  options
+
+prepareNetwork = (component, options, callback) ->
+  return callback null, options.network if options.network
+  # Start by loading the component
+  options.loader.load component, (err, instance) ->
+    return callback err if err
+    # Prepare a graph wrapping the component
+    graph = new Graph options.name
+    nodeName = options.name
+    graph.addNode nodeName, component
+    # Expose ports
+    # FIXME: direct process.component.inPorts/outPorts access is only for legacy compat
+    inPorts = instance.inPorts.ports or instance.inPorts
+    outPorts = instance.outPorts.ports or instance.outPorts
+    for port, def of inPorts
+      graph.addInport port, nodeName, port
+    for port, def of outPorts
+      graph.addOutport port, nodeName, port
+    # Prepare network
+    graph.componentLoader = options.loader
+    options.network = new Network graph, options
+    # Wire the network up and start execution
+    options.network.connect (err) ->
+      return callback err if err
+      callback null, options.network
+
+runNetwork = (network, inputs, options, callback) ->
+  process = network.getNode options.name
+  # Prepare inports
+  inPorts = Object.keys network.graph.inports
+  inSockets = {}
+  inPorts.forEach (inport) ->
+    inSockets[inport] = internalSocket.createSocket()
+    process.component.inPorts[inport].attach inSockets[inport]
+  # Subscribe outports
+  received = {}
+  outPorts = Object.keys network.graph.outports
+  outSockets = {}
+  outPorts.forEach (outport) ->
+    received[outport] = []
+    outSockets[outport] = internalSocket.createSocket()
+    process.component.outPorts[outport].attach outSockets[outport]
+    outSockets[outport].on 'ip', (ip) ->
+      received[outport].push ip
+  # Subscribe network finish
+  network.once 'end', ->
+    # Clear listeners
+    for port, socket of outSockets
+      process.component.outPorts[port].detach socket
+    outSockets = {}
+    inSockets = {}
+    callback null, received
+  # Start network
+  network.start (err) ->
+    return callback err if err
+    # Send inputs
+    inSockets[port].send value for port, value of inputs
+
+isMap = (inputs, network) ->
+  return false unless typeof inputs is 'object'
+  return false unless Object.keys(inputs).length
+  for key, value of inputs
+    return false unless network.graph.inports[key]
+  true
+
+prepareInputMap = (inputs, network) ->
+  return inputs if isMap inputs, network
+  # Not a map, send to first available inport
+  inPort = Object.keys(network.graph.inports)[0]
+  # If we have a port named "IN", send to that
+  inPort = 'in' if network.graph.inports.in
+  map = {}
+  map[inPort] = inputs
+  return map
+
+normalizeOutput = (values) ->
+  datas = values.filter (ip) -> ip.type is 'data'
+  if datas.length is 1
+    return datas[0].data
+  # TODO: Arrayize each stream
+  datas.map (ip) -> ip.data
+
+sendOutputMap = (outputs, useMap, callback) ->
+  if outputs.error?.length
+    # We've got errors
+    return callback normalizeOutput outputs.error
+  outputKeys = Object.keys outputs
+  withValue = outputKeys.filter (outport) ->
+    outputs[outport].length > 0
+  if withValue.length is 0
+    # No output
+    return callback null
+  if withValue.length is 1 and not useMap
+    # Single outport
+    callback null, normalizeOutput outputs[withValue[0]]
+  result = {}
+  for port, packets of outputs
+    result[port] = normalizeOutput packets
+  callback null, result
+
+exports.asCallback = (component, options) ->
+  options = normalizeOptions options, component
+  return (inputs, callback) ->
+    prepareNetwork component, options, (err, network) ->
+      return callback err if err
+      useMap = isMap inputs, network
+      inputMap = prepareInputMap inputs, network
+      runNetwork network, inputMap, options, (err, outputMap) ->
+        return callback err if err
+        sendOutputMap outputMap, useMap, callback

--- a/src/lib/AsCallback.coffee
+++ b/src/lib/AsCallback.coffee
@@ -88,11 +88,21 @@ prepareInputMap = (inputs, network) ->
   return map
 
 normalizeOutput = (values) ->
-  datas = values.filter (ip) -> ip.type is 'data'
-  if datas.length is 1
-    return datas[0].data
-  # TODO: Arrayize each stream
-  datas.map (ip) -> ip.data
+  result = []
+  previous = null
+  current = result
+  for packet in values
+    if packet.type is 'openBracket'
+      previous = current
+      current = []
+      previous.push current
+    if packet.type is 'data'
+      current.push packet.data
+    if packet.type is 'closeBracket'
+      current = previous
+  if result.length is 1
+    return result[0]
+  return result
 
 sendOutputMap = (outputs, useMap, callback) ->
   if outputs.error?.length

--- a/src/lib/AsCallback.coffee
+++ b/src/lib/AsCallback.coffee
@@ -1,3 +1,8 @@
+#     NoFlo - Flow-Based Programming for JavaScript
+#     (c) 2017 Flowhub UG
+#     NoFlo may be freely distributed under the MIT license
+#
+# asCallback helper embedding NoFlo components or graphs in other JavaScript programs.
 ComponentLoader = require('./ComponentLoader').ComponentLoader
 Network = require('./Network').Network
 IP = require('./IP')

--- a/src/lib/NoFlo.coffee
+++ b/src/lib/NoFlo.coffee
@@ -164,3 +164,19 @@ exports.loadFile = (file, options, callback) ->
 # NoFlo graph files can be saved back into the filesystem with this method.
 exports.saveFile = (graph, file, callback) ->
   exports.graph.save file, callback
+
+# ## Embedding NoFlo in existing JavaScript code
+#
+# The `asCallback` helper provides an interface to wrap NoFlo components
+# or graphs into existing JavaScript code.
+#
+#     // Produce an asynchronous function wrapping a NoFlo graph
+#     var wrapped = noflo.asCallback('myproject/MyGraph');
+#
+#     // Call the function, providing input data and a callback for output data
+#     wrapped({
+#       in: 'data'
+#     }, function (err, results) {
+#       // Do something with results
+#     });
+exports.asCallback = require('./AsCallback').asCallback


### PR DESCRIPTION
`noflo.asCallback(component, options)` accepts the following options at this stage:

* `loader`: instance of NoFlo ComponentLoader. If not provided, it will be loaded by the helper
* `baseDir`: basedir to use if no ComponentLoader is provided (defaults to `process.cwd()`)
* `raw`: return results as IP objects?

This returns a Node.js style function with signature `callbackified(input, callback)`.

The input can be one of the following:

* Simple value (will be sent to `IN` port if available, otherwise to first inport of the graph)
* Input map (object containing `portname: value` mappings where value can be either IP object or regular value)
* Sequence (array containing input maps)

This sets up a network, sends it the given inputs, and waits for network `end` event. At that point the received IP objects will be read.

If the execution caused something to be sent to `error` port, then the error (or array of errors) is given as first argument to the callback.

Otherwise the resulting IPs will be sent in same format as what the input used (simple values, map, or sequence). If `options.raw` was given, the outputs will be IP objects, otherwise their data.

Fixes #516 