### PR TITLE
Send IIPs on finished but not stopped network

### DIFF
--- a/spec/NetworkLifecycle.coffee
+++ b/spec/NetworkLifecycle.coffee
@@ -143,24 +143,25 @@ describe 'Network Lifecycle', ->
       loader.registerComponent 'legacy', 'Sync', legacyBasic
       done()
 
-  describe 'with single Process API component', ->
+  describe 'with single Process API component receiving IIP', ->
     c = null
+    g = null
     out = null
-    before (done) ->
+    beforeEach (done) ->
       fbpData = "
       OUTPORT=Pc.OUT:OUT
       'hello' -> IN Pc(process/Async)
       "
-      noflo.graph.loadFBP fbpData, (err, g) ->
+      noflo.graph.loadFBP fbpData, (err, graph) ->
         return done err if err
-        loader.registerComponent 'scope', 'Connected', g
+        g = graph
+        loader.registerComponent 'scope', 'Connected', graph
         loader.load 'scope/Connected', (err, instance) ->
           return done err if err
           c = instance
+          out = noflo.internalSocket.createSocket()
+          c.outPorts.out.attach out
           done()
-    beforeEach ->
-      out = noflo.internalSocket.createSocket()
-      c.outPorts.out.attach out
     afterEach (done) ->
       c.outPorts.out.detach out
       out = null
@@ -188,7 +189,6 @@ describe 'Network Lifecycle', ->
         done()
       c.network.once 'start', checkStart
       c.network.once 'end', checkEnd
-
       c.start (err) ->
         return done err if err
 

--- a/spec/NetworkLifecycle.coffee
+++ b/spec/NetworkLifecycle.coffee
@@ -211,7 +211,9 @@ describe 'Network Lifecycle', ->
         wasStarted = true
       checkEnd = ->
         chai.expect(wasStarted).to.equal true
-        if received.length <= expected.length
+        if received.length < expected.length
+          wasStarted = false
+          c.network.once 'start', checkStart
           c.network.once 'end', checkEnd
           g.addInitial 'world', 'Pc', 'in'
           return

--- a/spec/NetworkLifecycle.coffee
+++ b/spec/NetworkLifecycle.coffee
@@ -191,6 +191,36 @@ describe 'Network Lifecycle', ->
       c.network.once 'end', checkEnd
       c.start (err) ->
         return done err if err
+    it 'should execute twice if IIP changes', (done) ->
+      expected = [
+        'DATA helloPc'
+        'DATA worldPc'
+      ]
+      received = []
+      out.on 'ip', (ip) ->
+        switch ip.type
+          when 'openBracket'
+            received.push "< #{ip.data}"
+          when 'data'
+            received.push "DATA #{ip.data}"
+          when 'closeBracket'
+            received.push '>'
+      wasStarted = false
+      checkStart = ->
+        chai.expect(wasStarted).to.equal false
+        wasStarted = true
+      checkEnd = ->
+        chai.expect(wasStarted).to.equal true
+        if received.length <= expected.length
+          c.network.once 'end', checkEnd
+          g.addInitial 'world', 'Pc', 'in'
+          return
+        chai.expect(received).to.eql expected
+        done()
+      c.network.once 'start', checkStart
+      c.network.once 'end', checkEnd
+      c.start (err) ->
+        return done err if err
 
   describe 'with WirePattern sending to Process API', ->
     c = null

--- a/src/lib/Network.coffee
+++ b/src/lib/Network.coffee
@@ -652,7 +652,9 @@ class Network extends EventEmitter
 
     @abortDebounce = true if @debouncedEnd
 
-    return callback null unless @started
+    unless @started
+      @stopped = true
+      return callback null
 
     # Disconnect all connections
     for connection in @connections


### PR DESCRIPTION
We have an issue where new IIPs don't get sent if network already finished. To fix this we need to start distinguishing between "stopped" and "finished, but can be re-activated".