### PR TITLE
IP schema support

### DIFF
--- a/spec/Component.coffee
+++ b/spec/Component.coffee
@@ -614,6 +614,105 @@ describe 'Component', ->
       sin2.post new noflo.IP 'data', 'bar',
         groups: ['bar']
 
+    it 'should stamp IP objects with the datatype of the outport when sending', (done) ->
+      c = new noflo.Component
+        inPorts:
+          foo: datatype: 'all'
+        outPorts:
+          baz: datatype: 'string'
+        process: (input, output) ->
+          return unless input.has 'foo'
+          foo = input.get 'foo'
+          output.sendDone
+            baz: foo
+
+      c.inPorts.foo.attach sin1
+      c.outPorts.baz.attach sout1
+
+      sout1.once 'ip', (ip) ->
+        chai.expect(ip).to.be.an 'object'
+        chai.expect(ip.type).to.equal 'data'
+        chai.expect(ip.data).to.equal 'foo'
+        chai.expect(ip.datatype).to.equal 'string'
+        done()
+
+      sin1.post new noflo.IP 'data', 'foo'
+    it 'should stamp IP objects with the datatype of the inport when receiving', (done) ->
+      c = new noflo.Component
+        inPorts:
+          foo: datatype: 'string'
+        outPorts:
+          baz: datatype: 'all'
+        process: (input, output) ->
+          return unless input.has 'foo'
+          foo = input.get 'foo'
+          output.sendDone
+            baz: foo
+
+      c.inPorts.foo.attach sin1
+      c.outPorts.baz.attach sout1
+
+      sout1.once 'ip', (ip) ->
+        chai.expect(ip).to.be.an 'object'
+        chai.expect(ip.type).to.equal 'data'
+        chai.expect(ip.data).to.equal 'foo'
+        chai.expect(ip.datatype).to.equal 'string'
+        done()
+
+      sin1.post new noflo.IP 'data', 'foo'
+    it 'should stamp IP objects with the schema of the outport when sending', (done) ->
+      c = new noflo.Component
+        inPorts:
+          foo: datatype: 'all'
+        outPorts:
+          baz:
+            datatype: 'string'
+            schema: 'text/markdown'
+        process: (input, output) ->
+          return unless input.has 'foo'
+          foo = input.get 'foo'
+          output.sendDone
+            baz: foo
+
+      c.inPorts.foo.attach sin1
+      c.outPorts.baz.attach sout1
+
+      sout1.once 'ip', (ip) ->
+        chai.expect(ip).to.be.an 'object'
+        chai.expect(ip.type).to.equal 'data'
+        chai.expect(ip.data).to.equal 'foo'
+        chai.expect(ip.datatype).to.equal 'string'
+        chai.expect(ip.schema).to.equal 'text/markdown'
+        done()
+
+      sin1.post new noflo.IP 'data', 'foo'
+    it 'should stamp IP objects with the schema of the inport when receiving', (done) ->
+      c = new noflo.Component
+        inPorts:
+          foo:
+            datatype: 'string'
+            schema: 'text/markdown'
+        outPorts:
+          baz: datatype: 'all'
+        process: (input, output) ->
+          return unless input.has 'foo'
+          foo = input.get 'foo'
+          output.sendDone
+            baz: foo
+
+      c.inPorts.foo.attach sin1
+      c.outPorts.baz.attach sout1
+
+      sout1.once 'ip', (ip) ->
+        chai.expect(ip).to.be.an 'object'
+        chai.expect(ip.type).to.equal 'data'
+        chai.expect(ip.data).to.equal 'foo'
+        chai.expect(ip.datatype).to.equal 'string'
+        chai.expect(ip.schema).to.equal 'text/markdown'
+        done()
+
+      sin1.post new noflo.IP 'data', 'foo'
+
     it 'should receive and send just IP data if wanted', (done) ->
       c = new noflo.Component
         inPorts:

--- a/spec/IP.coffee
+++ b/spec/IP.coffee
@@ -29,9 +29,12 @@ describe 'IP object', ->
       owner: 'SomeProc'
       scope: 'request-12345'
       clonable: true
+      datatype: 'string'
+      schema: 'text/plain'
     d2 = d1.clone()
     chai.expect(d2).not.to.equal d1
     chai.expect(d2.type).to.equal d1.type
+    chai.expect(d2.schema).to.equal d1.schema
     chai.expect(d2.data).to.eql d1.data
     chai.expect(d2.groups).to.eql d2.groups
     chai.expect(d2.owner).not.to.equal d1.owner

--- a/spec/InPort.coffee
+++ b/spec/InPort.coffee
@@ -21,7 +21,7 @@ describe 'Inport Port', ->
       schema: 'text/url'
     it 'should retain the type', ->
       chai.expect(p.getDataType()).to.equal 'string'
-      chai.expect(p.options.schema).to.equal 'text/url'
+      chai.expect(p.getSchema()).to.equal 'text/url'
 
   describe 'without attached sockets', ->
     p = new noflo.InPort

--- a/spec/InPort.coffee
+++ b/spec/InPort.coffee
@@ -307,3 +307,52 @@ describe 'Inport Port', ->
       ps.inPorts.in.attach s
       chai.expect(ps.inPorts.in.listAttached()).to.eql [0]
       s.post new noflo.IP 'data', 'some-data'
+
+    it 'should stamp an IP object with the port\'s datatype', (done) ->
+      p = new noflo.InPort
+        datatype: 'string'
+      p.on 'ip', (data) ->
+        chai.expect(data).to.be.an 'object'
+        chai.expect(data.type).to.equal 'data'
+        chai.expect(data.data).to.equal 'Hello'
+        chai.expect(data.datatype).to.equal 'string'
+        done()
+      p.handleIP new noflo.IP 'data', 'Hello'
+    it 'should keep an IP object\'s datatype as-is if already set', (done) ->
+      p = new noflo.InPort
+        datatype: 'string'
+      p.on 'ip', (data) ->
+        chai.expect(data).to.be.an 'object'
+        chai.expect(data.type).to.equal 'data'
+        chai.expect(data.data).to.equal 123
+        chai.expect(data.datatype).to.equal 'integer'
+        done()
+      p.handleIP new noflo.IP 'data', 123,
+        datatype: 'integer'
+
+    it 'should stamp an IP object with the port\'s schema', (done) ->
+      p = new noflo.InPort
+        datatype: 'string'
+        schema: 'text/markdown'
+      p.on 'ip', (data) ->
+        chai.expect(data).to.be.an 'object'
+        chai.expect(data.type).to.equal 'data'
+        chai.expect(data.data).to.equal 'Hello'
+        chai.expect(data.datatype).to.equal 'string'
+        chai.expect(data.schema).to.equal 'text/markdown'
+        done()
+      p.handleIP new noflo.IP 'data', 'Hello'
+    it 'should keep an IP object\'s schema as-is if already set', (done) ->
+      p = new noflo.InPort
+        datatype: 'string'
+        schema: 'text/markdown'
+      p.on 'ip', (data) ->
+        chai.expect(data).to.be.an 'object'
+        chai.expect(data.type).to.equal 'data'
+        chai.expect(data.data).to.equal 'Hello'
+        chai.expect(data.datatype).to.equal 'string'
+        chai.expect(data.schema).to.equal 'text/plain'
+        done()
+      p.handleIP new noflo.IP 'data', 'Hello',
+        datatype: 'string'
+        schema: 'text/plain'

--- a/spec/InPort.coffee
+++ b/spec/InPort.coffee
@@ -18,10 +18,10 @@ describe 'Inport Port', ->
   describe 'with custom type', ->
     p = new noflo.InPort
       datatype: 'string'
-      type: 'text/url'
+      schema: 'text/url'
     it 'should retain the type', ->
       chai.expect(p.getDataType()).to.equal 'string'
-      chai.expect(p.options.type).to.equal 'text/url'
+      chai.expect(p.options.schema).to.equal 'text/url'
 
   describe 'without attached sockets', ->
     p = new noflo.InPort

--- a/spec/OutPort.coffee
+++ b/spec/OutPort.coffee
@@ -212,3 +212,56 @@ describe 'Outport Port', ->
 
       p.data obj,
         clonable: true
+
+    it 'should stamp an IP object with the port\'s datatype', (done) ->
+      p = new noflo.OutPort
+        datatype: 'string'
+      p.attach s1
+      s1.on 'ip', (data) ->
+        chai.expect(data).to.be.an 'object'
+        chai.expect(data.type).to.equal 'data'
+        chai.expect(data.data).to.equal 'Hello'
+        chai.expect(data.datatype).to.equal 'string'
+        done()
+      p.data 'Hello'
+    it 'should keep an IP object\'s datatype as-is if already set', (done) ->
+      p = new noflo.OutPort
+        datatype: 'string'
+      p.attach s1
+      s1.on 'ip', (data) ->
+        chai.expect(data).to.be.an 'object'
+        chai.expect(data.type).to.equal 'data'
+        chai.expect(data.data).to.equal 123
+        chai.expect(data.datatype).to.equal 'integer'
+        done()
+      p.sendIP new noflo.IP 'data', 123,
+        datatype: 'integer'
+
+    it 'should stamp an IP object with the port\'s schema', (done) ->
+      p = new noflo.OutPort
+        datatype: 'string'
+        schema: 'text/markdown'
+      p.attach s1
+      s1.on 'ip', (data) ->
+        chai.expect(data).to.be.an 'object'
+        chai.expect(data.type).to.equal 'data'
+        chai.expect(data.data).to.equal 'Hello'
+        chai.expect(data.datatype).to.equal 'string'
+        chai.expect(data.schema).to.equal 'text/markdown'
+        done()
+      p.data 'Hello'
+    it 'should keep an IP object\'s schema as-is if already set', (done) ->
+      p = new noflo.OutPort
+        datatype: 'string'
+        schema: 'text/markdown'
+      p.attach s1
+      s1.on 'ip', (data) ->
+        chai.expect(data).to.be.an 'object'
+        chai.expect(data.type).to.equal 'data'
+        chai.expect(data.data).to.equal 'Hello'
+        chai.expect(data.datatype).to.equal 'string'
+        chai.expect(data.schema).to.equal 'text/plain'
+        done()
+      p.sendIP new noflo.IP 'data', 'Hello',
+        datatype: 'string'
+        schema: 'text/plain'

--- a/src/lib/BasePort.coffee
+++ b/src/lib/BasePort.coffee
@@ -37,8 +37,11 @@ class BasePort extends EventEmitter
     if validTypes.indexOf(options.datatype) is -1
       throw new Error "Invalid port datatype '#{options.datatype}' specified, valid are #{validTypes.join(', ')}"
 
-    if options.type and options.type.indexOf('/') is -1
-      throw new Error "Invalid port type '#{options.type}' specified. Should be URL or MIME type"
+    if options.type and not options.schema
+      options.schema = options.type
+      delete options.type
+    if options.schema and options.schema.indexOf('/') is -1
+      throw new Error "Invalid port schema '#{options.schema}' specified. Should be URL or MIME type"
 
     @options = options
 

--- a/src/lib/BasePort.coffee
+++ b/src/lib/BasePort.coffee
@@ -51,6 +51,7 @@ class BasePort extends EventEmitter
     "#{@node} #{@name.toUpperCase()}"
 
   getDataType: -> @options.datatype
+  getSchema: -> @options.schema or null
   getDescription: -> @options.description
 
   attach: (socket, index = null) ->

--- a/src/lib/IP.coffee
+++ b/src/lib/IP.coffee
@@ -21,6 +21,8 @@ module.exports = class IP
     @owner = null # packet owner process
     @clonable = false # cloning safety flag
     @index = null # addressable port index
+    @schema = null
+    @datatype = 'all'
     for key, val of options
       this[key] = val
 

--- a/src/lib/InPort.coffee
+++ b/src/lib/InPort.coffee
@@ -71,6 +71,12 @@ class InPort extends BasePort
     return if @options.control and ip.type isnt 'data'
     ip.owner = @nodeInstance
     ip.index = id if @isAddressable()
+    if ip.datatype is 'all'
+      # Stamp non-specific IP objects with port datatype
+      ip.datatype = @getDataType()
+    if @getSchema() and not ip.schema
+      # Stamp non-specific IP objects with port schema
+      ip.schema = @getSchema()
 
     buf = @prepareBufferForIP ip
     buf.push ip

--- a/src/lib/OutPort.coffee
+++ b/src/lib/OutPort.coffee
@@ -61,6 +61,14 @@ class OutPort extends BasePort
       ip = new IP type, data, options
     sockets = @getSockets socketId
     @checkRequired sockets
+
+    if ip.datatype is 'all'
+      # Stamp non-specific IP objects with port datatype
+      ip.datatype = @getDataType()
+    if @getSchema() and not ip.schema
+      # Stamp non-specific IP objects with port schema
+      ip.schema = @getSchema()
+
     if @isCaching() and data isnt @cache[socketId]?.data
       @cache[socketId] = ip
     pristine = true

--- a/src/lib/Port.coffee
+++ b/src/lib/Port.coffee
@@ -25,6 +25,7 @@ class Port extends EventEmitter
     "#{@node} #{@name.toUpperCase()}"
 
   getDataType: -> @type
+  getSchema: -> null
   getDescription: -> @description
 
   attach: (socket) ->


### PR DESCRIPTION
We support data schema definitions on port level, allowing associating ports with RDF/JSON schemas. However, this information gets lost when a packet is transmitted. We should make ports "stamp" an IP object with the schema used.

Proposed stamping hierarchy:

* If IP object has explicit schema, use it as-is
* If sending outport has schema, set that as IP object's schema if there is none set
* If receiving inport has schema, set that as IP object's schema if there is none set

Related to noflo/noflo-ui#122

* [x] Rename port `type` to `schema`
* [x] Add schema support for IP objects
* [x] Add schema "stamping" support for out/inports
* [x] End-to-end tests with components
