### PR TITLE
WIP: Switch to CoffeeScript 2.x

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -52,7 +52,7 @@ module.exports = ->
         options:
           reporter: 'spec'
           require: [
-            'coffee-script/register'
+            'coffeescript/register'
             'coffee-coverage/register-istanbul'
           ]
           grep: process.env.TESTS

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">= 4"
   },
   "dependencies": {
-    "coffee-script": "~1.12.0",
+    "coffeescript": "^2.0.0",
     "debug": "^3.0.0",
     "fbp": "~1.5.0",
     "fbp-graph": "^0.1.0",

--- a/src/lib/loader/NodeJs.coffee
+++ b/src/lib/loader/NodeJs.coffee
@@ -5,7 +5,7 @@ utils = require '../Utils'
 fbpGraph = require 'fbp-graph'
 
 # We allow components to be un-compiled CoffeeScript
-CoffeeScript = require 'coffee-script'
+CoffeeScript = require 'coffeescript'
 if typeof CoffeeScript.register != 'undefined'
   CoffeeScript.register()
 


### PR DESCRIPTION
* [x] Depend on coffeescript, not coffee-script
* [x] Build browser version with coffee-loader 0.8 (which supports coffeescript 2)
* [ ] Distribute JavaScript version built with CoffeeScript 2.x instead or 1.x, waiting for gruntjs/grunt-contrib-coffee#196
* [ ] Document updated Node.js version dependency (or requirement to babel first)