### PR TITLE
Unscoped output ports

### DIFF
--- a/spec/Scoping.coffee
+++ b/spec/Scoping.coffee
@@ -99,6 +99,20 @@ processMergeUnscoped = ->
     output.sendDone
       out: "1#{first}:2#{second}:#{c.nodeId}"
 
+processUnscope = ->
+  c = new noflo.Component
+  c.inPorts.add 'in',
+    datatype: 'string'
+  c.outPorts.add 'out',
+    datatype: 'string'
+    scoped: false
+
+  c.process (input, output) ->
+    data = input.getData 'in'
+    setTimeout ->
+      output.sendDone data + c.nodeId
+    , 1
+
 # Merge with an addressable port
 processMergeA = ->
   c = new noflo.Component
@@ -133,6 +147,7 @@ describe 'Scope isolation', ->
       loader.registerComponent 'process', 'Async', processAsync
       loader.registerComponent 'process', 'Merge', processMerge
       loader.registerComponent 'process', 'MergeA', processMergeA
+      loader.registerComponent 'process', 'Unscope', processUnscope
       loader.registerComponent 'process', 'MergeUnscoped', processMergeUnscoped
       done()
 
@@ -457,7 +472,7 @@ describe 'Scope isolation', ->
       in1.post new noflo.IP 'data', 'one', scope: 'x'
       in1.post new noflo.IP 'closeBracket', 1, scope: 'x'
 
-  describe 'Process API with unscoped port and scopes', ->
+  describe 'Process API with unscoped inport and scopes', ->
     c = null
     in1 = null
     in2 = null
@@ -572,6 +587,122 @@ describe 'Scope isolation', ->
       in1.post new noflo.IP 'openBracket', 1, scope: 'x'
       in1.post new noflo.IP 'data', 'one', scope: 'x'
       in1.post new noflo.IP 'closeBracket', 1, scope: 'x'
+
+  describe 'Process API with unscoped outport and scopes', ->
+    c = null
+    in1 = null
+    in2 = null
+    out = null
+    before (done) ->
+      fbpData = "
+      INPORT=Pc1.IN:IN1
+      INPORT=Pc2.IN:IN2
+      OUTPORT=PcMerge.OUT:OUT
+      Pc1(process/Unscope) -> IN1 PcMerge(process/Merge)
+      Pc2(process/Unscope) -> IN2 PcMerge
+      "
+      noflo.graph.loadFBP fbpData, (err, g) ->
+        return done err if err
+        loader.registerComponent 'scope', 'MergeUnscopedOut', g
+        loader.load 'scope/MergeUnscopedOut', (err, instance) ->
+          return done err if err
+          c = instance
+          in1 = noflo.internalSocket.createSocket()
+          c.inPorts.in1.attach in1
+          in2 = noflo.internalSocket.createSocket()
+          c.inPorts.in2.attach in2
+          done()
+    beforeEach ->
+      out = noflo.internalSocket.createSocket()
+      c.outPorts.out.attach out
+    afterEach ->
+      c.outPorts.out.detach out
+      out = null
+    it 'should remove scopes as expected', (done) ->
+      expected = [
+        'null < 1'
+        'null DATA 1onePc1:2twoPc2:PcMerge'
+        'null >'
+      ]
+      received = []
+      brackets = []
+
+      out.on 'ip', (ip) ->
+        switch ip.type
+          when 'openBracket'
+            received.push "#{ip.scope} < #{ip.data}"
+            brackets.push ip.data
+          when 'data'
+            received.push "#{ip.scope} DATA #{ip.data}"
+          when 'closeBracket'
+            received.push "#{ip.scope} >"
+            brackets.pop()
+            return if brackets.length
+            chai.expect(received).to.eql expected
+            done()
+
+      in1.post new noflo.IP 'openBracket', 1, scope: 'x'
+      in1.post new noflo.IP 'data', 'one', scope: 'x'
+      in1.post new noflo.IP 'closeBracket', 1, scope: 'x'
+      in2.post new noflo.IP 'openBracket', 1, scope: 'y'
+      in2.post new noflo.IP 'data', 'two', scope: 'y'
+      in2.post new noflo.IP 'closeBracket', 1, scope: 'y'
+    it 'should forward packets without scopes', (done) ->
+      expected = [
+        'null < 1'
+        'null DATA 1onePc1:2twoPc2:PcMerge'
+        'null >'
+      ]
+      received = []
+      brackets = []
+
+      out.on 'ip', (ip) ->
+        switch ip.type
+          when 'openBracket'
+            received.push "#{ip.scope} < #{ip.data}"
+            brackets.push ip.data
+          when 'data'
+            received.push "#{ip.scope} DATA #{ip.data}"
+          when 'closeBracket'
+            received.push "#{ip.scope} >"
+            brackets.pop()
+            return if brackets.length
+            chai.expect(received).to.eql expected
+            done()
+      in1.post new noflo.IP 'openBracket', 1
+      in1.post new noflo.IP 'data', 'one'
+      in1.post new noflo.IP 'closeBracket'
+      in2.post new noflo.IP 'openBracket', 1
+      in2.post new noflo.IP 'data', 'two'
+      in2.post new noflo.IP 'closeBracket', 1
+    it 'should remove scopes also on unscoped packet', (done) ->
+      expected = [
+        'null < 1'
+        'null DATA 1onePc1:2twoPc2:PcMerge'
+        'null >'
+      ]
+      received = []
+      brackets = []
+
+      out.on 'ip', (ip) ->
+        switch ip.type
+          when 'openBracket'
+            received.push "#{ip.scope} < #{ip.data}"
+            brackets.push ip.data
+          when 'data'
+            received.push "#{ip.scope} DATA #{ip.data}"
+          when 'closeBracket'
+            received.push "#{ip.scope} >"
+            brackets.pop()
+            return if brackets.length
+            chai.expect(received).to.eql expected
+            done()
+      in1.post new noflo.IP 'openBracket', 1, scope: 'x'
+      in1.post new noflo.IP 'data', 'one', scope: 'x'
+      in1.post new noflo.IP 'closeBracket', 1, scope: 'x'
+      in2.post new noflo.IP 'openBracket', 1
+      in2.post new noflo.IP 'data', 'two'
+      in2.post new noflo.IP 'closeBracket', 1
 
   describe 'Process API with IIPs to addressable ports and scopes', ->
     c = null

--- a/src/lib/Component.coffee
+++ b/src/lib/Component.coffee
@@ -374,6 +374,8 @@ class Component extends EventEmitter
                 debugSend "#{@nodeId} sending #{portIdentifier} > '#{ip.data}'"
               else
                 debugSend "#{@nodeId} sending #{portIdentifier} DATA"
+              unless @outPorts[port].options.scoped
+                ip.scope = null
               @outPorts[port].sendIP ip
           continue
         continue unless @outPorts.ports[port].isAttached()
@@ -385,6 +387,8 @@ class Component extends EventEmitter
             debugSend "#{@nodeId} sending #{portIdentifier} > '#{ip.data}'"
           else
             debugSend "#{@nodeId} sending #{portIdentifier} DATA"
+          unless @outPorts[port].options.scoped
+            ip.scope = null
           @outPorts[port].sendIP ip
 
   activate: (context) ->
@@ -689,6 +693,8 @@ class ProcessOutput
     if @nodeInstance.isOrdered()
       @nodeInstance.addToResult @result, port, ip
       return
+    unless @nodeInstance.outPorts[port].options.scoped
+      ip.scope = null
     @nodeInstance.outPorts[port].sendIP ip
 
   # Sends packets for each port as a key in the map

--- a/src/lib/OutPort.coffee
+++ b/src/lib/OutPort.coffee
@@ -9,6 +9,8 @@ IP = require './IP'
 class OutPort extends BasePort
   constructor: (options) ->
     @cache = {}
+    options ?= {}
+    options.scoped ?= true
     super options
 
   attach: (socket, index = null) ->


### PR DESCRIPTION
This adds an "escape" from scoped world by declaring an outport to be `scoped: false`.

Adds symmetry with the inport unscoped feature.