### PR TITLE
IP events only on network

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "chai": "^4.0.0",
     "coffee-coverage": "^2.0.1",
-    "coffee-loader": "^0.8.0",
+    "coffee-loader": "^0.7.2",
     "coveralls": "^3.0.0",
     "fbp-loader": "^0.1.1",
     "grunt": "^1.0.1",

--- a/spec/Network.coffee
+++ b/spec/Network.coffee
@@ -170,10 +170,6 @@ describe 'NoFlo Network', ->
         done()
       n.sendInitials()
 
-    describe 'once started', ->
-      it 'should be marked as started', ->
-        chai.expect(n.isStarted()).to.equal true
-
     describe 'with a renamed node', ->
       it 'should have the process in a new location', (done) ->
         g.once 'renameNode', ->

--- a/spec/NetworkLifecycle.coffee
+++ b/spec/NetworkLifecycle.coffee
@@ -980,17 +980,11 @@ describe 'Network Lifecycle', ->
     it 'should forward new-style brackets as expected', (done) ->
       expected = [
         'START'
-        'DATA -> IN Leg2() CONN'
-        'Leg2() OUT -> IN2 PcMerge() CONN'
         'DATA -> IN Leg2() DATA foo'
         'Leg2() OUT -> IN2 PcMerge() DATA fooLeg2'
-        'Leg2() OUT -> IN2 PcMerge() DISC'
-        'DATA -> IN Leg2() DISC'
-        'Leg1() OUT -> IN1 PcMerge() CONN'
         'Leg1() OUT -> IN1 PcMerge() < 1'
         'Leg1() OUT -> IN1 PcMerge() < a'
         'Leg1() OUT -> IN1 PcMerge() DATA bazLeg1'
-        'PcMerge() OUT -> IN Wp() CONN'
         'PcMerge() OUT -> IN Wp() < 1'
         'PcMerge() OUT -> IN Wp() < a'
         'PcMerge() OUT -> IN Wp() DATA 1bazLeg1:2fooLeg2:PcMerge'
@@ -998,15 +992,11 @@ describe 'Network Lifecycle', ->
         'PcMerge() OUT -> IN Wp() > a'
         'Leg1() OUT -> IN1 PcMerge() > 1'
         'PcMerge() OUT -> IN Wp() > 1'
-        'PcMerge() OUT -> IN Wp() DISC'
-        'Leg1() OUT -> IN1 PcMerge() DISC'
-        'Wp() OUT -> IN Leg3() CONN'
         'Wp() OUT -> IN Leg3() < 1'
         'Wp() OUT -> IN Leg3() < a'
         'Wp() OUT -> IN Leg3() DATA 1bazLeg1:2fooLeg2:PcMergeWp'
         'Wp() OUT -> IN Leg3() > a'
         'Wp() OUT -> IN Leg3() > 1'
-        'Wp() OUT -> IN Leg3() DISC'
         'END'
       ]
       received = []


### PR DESCRIPTION
Related to #480 and noflo/noflo-runtime-base#101, we no longer should emit `connect` and `disconnect` events on network level. With this, we can subscribe to only `ip` on sockets and subgraphs, reducing the amount of listeners we registrate