### PR TITLE
Warn about legacy API components

### DIFF
--- a/src/components/Graph.coffee
+++ b/src/components/Graph.coffee
@@ -146,6 +146,9 @@ class Graph extends noflo.Component
   isSubgraph: ->
     true
 
+  isLegacy: ->
+    false
+
   setUp: (callback) ->
     @starting = true
     unless @isReady()

--- a/src/lib/Component.coffee
+++ b/src/lib/Component.coffee
@@ -145,8 +145,6 @@ class Component extends EventEmitter
   isLegacy: ->
     # Process API
     return false if @handle
-    # WirePattern
-    return false if @_wpData
     # Legacy
     true
 

--- a/src/lib/ComponentLoader.coffee
+++ b/src/lib/ComponentLoader.coffee
@@ -68,7 +68,7 @@ class ComponentLoader extends EventEmitter
         return
 
     if @isGraph component
-      if typeof process isnt 'undefined' and process.execPath and process.execPath.indexOf('node') isnt -1
+      unless platform.isBrowser()
         # nextTick is faster on Node.js
         process.nextTick =>
           @loadGraph name, component, callback, metadata

--- a/src/lib/ComponentLoader.coffee
+++ b/src/lib/ComponentLoader.coffee
@@ -8,6 +8,7 @@ internalSocket = require './InternalSocket'
 fbpGraph = require 'fbp-graph'
 {EventEmitter} = require 'events'
 registerLoader = require './loader/register'
+platform = require './Platform'
 
 class ComponentLoader extends EventEmitter
   constructor: (baseDir, options = {}) ->
@@ -85,6 +86,9 @@ class ComponentLoader extends EventEmitter
 
       instance.baseDir = @baseDir if name is 'Graph'
       instance.componentName = name if typeof name is 'string'
+
+      if instance.isLegacy()
+        platform.deprecated "Component #{name} uses legacy NoFlo APIs. Please port to Process API"
 
       @setIcon name, instance
       callback null, instance


### PR DESCRIPTION
We previously didn't have detection for components using legacy (pre-WirePattern, pre-AsyncComponent, pre-ProcessAPI) component API.

This adds warning for such components so that they can be found and updated.