### PR TITLE
Improve setSource test coverage

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -85,7 +85,10 @@ module.exports = ->
     noflo_browser_mocha:
       all:
         options:
-          scripts: ["../browser/<%=pkg.name%>.js"]
+          scripts: [
+            "../browser/<%=pkg.name%>.js"
+            "https://cdnjs.cloudflare.com/ajax/libs/coffee-script/1.7.1/coffee-script.min.js"
+          ]
         files:
           'spec/runner.html': ['spec/*.js']
     # BDD tests on browser

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt-contrib-watch": "^1.0.0",
     "grunt-mocha-phantomjs": "^4.0.0",
     "grunt-mocha-test": "^0.13.2",
-    "grunt-noflo-browser": "^1.4.0",
+    "grunt-noflo-browser": "^1.5.2",
     "mocha": "^4.0.0",
     "nyc": "^11.2.1"
   },

--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -260,9 +260,6 @@ describe 'ComponentLoader with no external packages installed', ->
 
   describe 'writing sources', ->
     describe 'with working code', ->
-      before ->
-        # setSource not implemented in webpack loader yet
-        return @skip() if noflo.isBrowser()
       workingSource = """
       var noflo = require('noflo');
 

--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -278,7 +278,7 @@ describe 'ComponentLoader with no external packages installed', ->
           @timeout 10000
           unless noflo.isBrowser()
             workingSource = workingSource.replace "'noflo'", "'../src/lib/NoFlo'"
-          l.setSource 'foo', 'RepeatData', workingSource, 'js', (err) ->
+          l.setSource 'foo', 'RepeatData', workingSource, 'javascript', (err) ->
             return done err if err
             done()
         it 'should be a loadable component', (done) ->
@@ -296,6 +296,39 @@ describe 'ComponentLoader with no external packages installed', ->
               chai.expect(ip.data).to.equal 'ES5'
               done()
             ins.send 'ES5'
+      describe 'with CoffeeScript', ->
+        workingSource = """
+        noflo = require 'noflo'
+        exports.getComponent = ->
+          c = new noflo.Component
+          c.inPorts.add 'in'
+          c.outPorts.add 'out'
+          c.process (input, output) ->
+            output.sendDone input.get 'in'
+        """
+
+        it 'should be able to set the source', (done) ->
+          @timeout 10000
+          unless noflo.isBrowser()
+            workingSource = workingSource.replace "'noflo'", "'../src/lib/NoFlo'"
+          l.setSource 'foo', 'RepeatDataCoffee', workingSource, 'coffeescript', (err) ->
+            return done err if err
+            done()
+        it 'should be a loadable component', (done) ->
+          l.load 'foo/RepeatDataCoffee', (err, inst) ->
+            return done err if err
+            chai.expect(inst).to.be.an 'object'
+            chai.expect(inst.inPorts).to.contain.keys ['in']
+            chai.expect(inst.outPorts).to.contain.keys ['out']
+            ins = new noflo.internalSocket.InternalSocket
+            out = new noflo.internalSocket.InternalSocket
+            inst.inPorts.in.attach ins
+            inst.outPorts.out.attach out
+            out.on 'ip', (ip) ->
+              chai.expect(ip.type).to.equal 'data'
+              chai.expect(ip.data).to.equal 'CoffeeScript'
+              done()
+            ins.send 'CoffeeScript'
 
     describe 'with non-working code', ->
       before ->

--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -370,9 +370,6 @@ describe 'ComponentLoader with no external packages installed', ->
             ins.send 'CoffeeScript'
 
     describe 'with non-working code', ->
-      before ->
-        # setSource not implemented in webpack loader yet
-        return @skip() if noflo.isBrowser()
       nonWorkingSource = """
       var noflo = require('noflo');
       var notFound = require('./this_file_does_not_exist.js');

--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -336,6 +336,10 @@ describe 'ComponentLoader with no external packages installed', ->
               done()
             ins.send 'ES6'
       describe 'with CoffeeScript', ->
+        before ->
+          # CoffeeScript tests work in browser only if we have CoffeeScript
+          # compiler loaded
+          return @skip() if noflo.isBrowser() and not window.CoffeeScript
         workingSource = """
         noflo = require 'noflo'
         exports.getComponent = ->

--- a/spec/ComponentLoader.coffee
+++ b/spec/ComponentLoader.coffee
@@ -162,11 +162,25 @@ describe 'ComponentLoader with no external packages installed', ->
       chai.expect(instance.baseDir).to.equal l.baseDir
 
   describe 'loading a component', ->
+    loader = null
+    before (done) ->
+      loader = new noflo.ComponentLoader root
+      loader.listComponents done
     it 'should return an error on an invalid component type', (done) ->
-      l.components['InvalidComponent'] = true
-      l.load 'InvalidComponent', (err, c) ->
-        chai.expect(err).to.be.instanceOf Error
+      loader.components['InvalidComponent'] = true
+      loader.load 'InvalidComponent', (err, c) ->
+        chai.expect(err).to.be.an 'error'
         chai.expect(err.message).to.equal 'Invalid type boolean for component InvalidComponent.'
+        done()
+    it 'should return an error on a missing component path', (done) ->
+      loader.components['InvalidComponent'] = 'missing-file.js'
+      if noflo.isBrowser()
+        str = 'Dynamic loading of'
+      else
+        str = 'Cannot find module'
+      loader.load 'InvalidComponent', (err, c) ->
+        chai.expect(err).to.be.an 'error'
+        chai.expect(err.message).to.contain str
         done()
 
   describe 'register a component at runtime', ->

--- a/src/lib/ComponentLoader.coffee
+++ b/src/lib/ComponentLoader.coffee
@@ -108,10 +108,16 @@ class ComponentLoader extends EventEmitter
 
     # Attempt to create the component instance using the `getComponent` method.
     if typeof implementation.getComponent is 'function'
-      instance = implementation.getComponent metadata
+      try
+        instance = implementation.getComponent metadata
+      catch e
+        return callback e
     # Attempt to create a component using a factory function.
     else if typeof implementation is 'function'
-      instance = implementation metadata
+      try
+        instance = implementation metadata
+      catch e
+        return callback e
     else
       callback new Error "Invalid type #{typeof(implementation)} for component #{name}."
       return

--- a/src/lib/loader/NodeJs.coffee
+++ b/src/lib/loader/NodeJs.coffee
@@ -137,7 +137,7 @@ exports.setSource = (loader, packageId, name, source, language, callback) ->
     implementation = moduleImpl.exports
   catch e
     return callback e
-  unless implementation or implementation.getComponent
+  unless typeof implementation is 'function' or typeof implementation.getComponent is 'function'
     return callback new Error 'Provided source failed to create a runnable component'
 
   loader.registerComponent packageId, name, implementation, callback

--- a/src/lib/loader/NodeJs.coffee
+++ b/src/lib/loader/NodeJs.coffee
@@ -127,13 +127,6 @@ exports.setSource = (loader, packageId, name, source, language, callback) ->
         bare: true
     catch e
       return callback e
-  else if language in ['es6', 'es2015']
-    try
-      babel = require 'babel-core'
-      source = babel.transform(source).code
-    catch e
-      return callback e
-
   try
     # Use the Node.js module API to evaluate in the correct directory context
     modulePath = path.resolve loader.baseDir, "./components/#{name}.js"


### PR DESCRIPTION
* [x] Run setSource tests also on browser
* [x] Remove babelizing ES6 from Node.js setSource since all supported Node.js versions support ES6 (was introduced in #294)
* [x] Include CoffeeScript compiler in browser test runner