### PR TITLE
Allow using noflo.asCallback with a graph instance

### DIFF
--- a/spec/AsCallback.coffee
+++ b/spec/AsCallback.coffee
@@ -235,3 +235,35 @@ describe 'asCallback interface', ->
             'closeBracket 1'
           ]
           done()
+  describe 'with a graph instead of component name', ->
+    graph = null
+    wrapped = null
+    before (done) ->
+      noflo.graph.loadFBP """
+      INPORT=Async.IN:IN
+      OUTPORT=Stream.OUT:OUT
+      Async(process/Async) OUT -> IN Stream(process/Streamify)
+      """, (err, g) ->
+        return done err if err
+        graph = g
+        wrapped = noflo.asCallback graph,
+          loader: loader
+        done()
+    it 'should execute network with input map and provide output map with streams as arrays', (done) ->
+      wrapped
+        in: 'hello world'
+      , (err, out) ->
+        return done err if err
+        chai.expect(out.out).to.eql [
+          ['h','e','l','l','o']
+          ['w','o','r','l','d']
+        ]
+        done()
+    it 'should execute network with simple input and and provide simple output with streams as arrays', (done) ->
+      wrapped 'hello there', (err, out) ->
+        return done err if err
+        chai.expect(out).to.eql [
+          ['h','e','l','l','o']
+          ['t','h','e','r','e']
+        ]
+        done()

--- a/src/lib/AsCallback.coffee
+++ b/src/lib/AsCallback.coffee
@@ -22,6 +22,16 @@ normalizeOptions = (options, component) ->
   options
 
 prepareNetwork = (component, options, callback) ->
+  # If we were given a graph instance, then just create a network
+  if typeof component is 'object'
+    component.componentLoader = options.loader
+    network = new Network component, options
+    # Wire the network up
+    network.connect (err) ->
+      return callback err if err
+      callback null, network
+    return
+
   # Start by loading the component
   options.loader.load component, (err, instance) ->
     return callback err if err


### PR DESCRIPTION
Right now, the [`noflo.asCallback` embedding API](https://noflojs.org/documentation/embedding/#ascallback) only works with registered components or subgraphs.

To make it more flexible (as requested in #582), this PR adds a way to call it with a `noflo.Graph` instance as well.

So, you can either:

```javascript
const wrapped = noflo.asCallback('myproject/Component');
wrapped(inputs, (err, outputs) => {});
```

or:

```javascript
noflo.graph.loadFBP(`SOME FBP DATA`, (err, graph) => {
  const wrapped = noflo.asCallback(graph);
  wrapped(inputs, (err, outputs) => {});
});
```

Obviously the NoFlo graph can be constructed in whatever way... by loading JSON or FBP, or by using the graph API directly. However, it must have exported ports for this to work.