### PR TITLE
asComponent to componentize JavaScript functions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2017 Flowhub UG
+Copyright (c) 2013-2018 Flowhub UG
 Copyright (c) 2011-2012 Henri Bergius, Nemein
 
 Permission is hereby granted, free of charge, to any person

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "debug": "^3.0.0",
     "fbp": "^1.5.0",
     "fbp-graph": "^0.3.1",
-    "fbp-manifest": "^0.2.0"
+    "fbp-manifest": "^0.2.0",
+    "get-function-params": "^2.0.3"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/spec/AsComponent.coffee
+++ b/spec/AsComponent.coffee
@@ -78,10 +78,10 @@ describe 'asComponent interface', ->
             out: 'Hei Maailma'
           done()
   describe 'with a function returning a Promise', ->
-    before ->
-      if isBrowser and typeof window.Promise is 'undefined'
-        return @skip()
     describe 'with a resolved promise', ->
+      before ->
+        if isBrowser and typeof window.Promise is 'undefined'
+          return @skip()
       func = (hello) ->
         return new Promise (resolve, reject) ->
           setTimeout ->
@@ -98,6 +98,9 @@ describe 'asComponent interface', ->
           chai.expect(res).to.equal 'Hello World'
           done()
     describe 'with a rejected promise', ->
+      before ->
+        if isBrowser and typeof window.Promise is 'undefined'
+          return @skip()
       func = (hello) ->
         return new Promise (resolve, reject) ->
           setTimeout ->

--- a/spec/AsComponent.coffee
+++ b/spec/AsComponent.coffee
@@ -4,10 +4,12 @@ if typeof process isnt 'undefined' and process.execPath and process.execPath.mat
   path = require 'path'
   root = path.resolve __dirname, '../'
   urlPrefix = './'
+  isBrowser = false
 else
   noflo = require 'noflo'
   root = 'noflo'
   urlPrefix = '/'
+  isBrowser = true
 
 describe 'asComponent interface', ->
   loader = null
@@ -77,7 +79,7 @@ describe 'asComponent interface', ->
           done()
   describe 'with a function returning a Promise', ->
     before ->
-      if typeof Promise is 'undefined'
+      if isBrowser and typeof window.Promise is 'undefined'
         return @skip()
     describe 'with a resolved promise', ->
       func = (hello) ->

--- a/spec/AsComponent.coffee
+++ b/spec/AsComponent.coffee
@@ -136,6 +136,23 @@ describe 'asComponent interface', ->
           return done err if err
           chai.expect(res).to.equal 'Hello there'
           done()
+    describe 'with a built-in function', ->
+      it 'should be possible to componentize', (done) ->
+        component = -> noflo.asComponent Math.random
+        loader.registerComponent 'ascomponent', 'sync-zero', component, done
+      it 'should contain correct ports', (done) ->
+        loader.load 'ascomponent/sync-zero', (err, instance) ->
+          return done err if err
+          chai.expect(Object.keys(instance.inPorts.ports)).to.eql ['in']
+          chai.expect(Object.keys(instance.outPorts.ports)).to.eql ['out', 'error']
+          done()
+      it 'should send to OUT port', (done) ->
+        wrapped = noflo.asCallback 'ascomponent/sync-zero',
+          loader: loader
+        wrapped 'bang', (err, res) ->
+          return done err if err
+          chai.expect(res).to.be.a 'number'
+          done()
   describe 'with an asynchronous function taking a single parameter and callback', ->
     describe 'with successful callback', ->
       func = (hello, callback) ->

--- a/spec/AsComponent.coffee
+++ b/spec/AsComponent.coffee
@@ -108,7 +108,7 @@ describe 'asComponent interface', ->
           done()
     describe 'with a default value', ->
       before ->
-        @skip() if isBrowser
+        @skip() if isBrowser # Browser runs with ES5 which didn't have defaults
       func = (name, greeting = 'Hello') ->
         return "#{greeting} #{name}"
       it 'should be possible to componentize', (done) ->

--- a/spec/AsComponent.coffee
+++ b/spec/AsComponent.coffee
@@ -1,0 +1,113 @@
+if typeof process isnt 'undefined' and process.execPath and process.execPath.match /node|iojs/
+  chai = require 'chai' unless chai
+  noflo = require '../src/lib/NoFlo.coffee'
+  path = require 'path'
+  root = path.resolve __dirname, '../'
+  urlPrefix = './'
+else
+  noflo = require 'noflo'
+  root = 'noflo'
+  urlPrefix = '/'
+
+describe 'asComponent interface', ->
+  loader = null
+  before (done) ->
+    loader = new noflo.ComponentLoader root
+    loader.listComponents done
+  describe 'with a synchronous function taking a single parameter', ->
+    describe 'with returned value', ->
+      func = (hello) ->
+        return "Hello #{hello}"
+      it 'should be possible to componentize', (done) ->
+        component = -> noflo.asComponent func
+        loader.registerComponent 'ascomponent', 'sync-one', component, done
+      it 'should be loadable', (done) ->
+        loader.load 'ascomponent/sync-one', done
+      it 'should contain correct ports', (done) ->
+        loader.load 'ascomponent/sync-one', (err, instance) ->
+          return done err if err
+          chai.expect(Object.keys(instance.inPorts.ports)).to.eql ['hello']
+          chai.expect(Object.keys(instance.outPorts.ports)).to.eql ['out', 'error']
+          done()
+      it 'should send to OUT port', (done) ->
+        wrapped = noflo.asCallback 'ascomponent/sync-one',
+          loader: loader
+        wrapped 'World', (err, res) ->
+          return done err if err
+          chai.expect(res).to.equal 'Hello World'
+          done()
+    describe 'with a thrown exception', ->
+      func = (hello) ->
+        throw new Error "Hello #{hello}"
+      it 'should be possible to componentize', (done) ->
+        component = -> noflo.asComponent func
+        loader.registerComponent 'ascomponent', 'sync-throw', component, done
+      it 'should send to ERROR port', (done) ->
+        wrapped = noflo.asCallback 'ascomponent/sync-throw',
+          loader: loader
+        wrapped 'Error', (err) ->
+          chai.expect(err).to.be.an 'error'
+          chai.expect(err.message).to.equal 'Hello Error'
+          done()
+  describe 'with a synchronous function taking a multiple parameters', ->
+    describe 'with returned value', ->
+      func = (greeting, name) ->
+        return "#{greeting} #{name}"
+      it 'should be possible to componentize', (done) ->
+        component = -> noflo.asComponent func
+        loader.registerComponent 'ascomponent', 'sync-two', component, done
+      it 'should be loadable', (done) ->
+        loader.load 'ascomponent/sync-two', done
+      it 'should contain correct ports', (done) ->
+        loader.load 'ascomponent/sync-two', (err, instance) ->
+          return done err if err
+          chai.expect(Object.keys(instance.inPorts.ports)).to.eql ['greeting', 'name']
+          chai.expect(Object.keys(instance.outPorts.ports)).to.eql ['out', 'error']
+          done()
+      it 'should send to OUT port', (done) ->
+        wrapped = noflo.asCallback 'ascomponent/sync-two',
+          loader: loader
+        wrapped
+          greeting: 'Hei'
+          name: 'Maailma'
+        , (err, res) ->
+          return done err if err
+          chai.expect(res).to.eql
+            out: 'Hei Maailma'
+          done()
+  describe 'with a function returning a Promise', ->
+    before ->
+      if typeof Promise is 'undefined'
+        return @skip()
+    describe 'with a resolved promise', ->
+      func = (hello) ->
+        return new Promise (resolve, reject) ->
+          setTimeout ->
+            resolve "Hello #{hello}"
+          , 5
+      it 'should be possible to componentize', (done) ->
+        component = -> noflo.asComponent func
+        loader.registerComponent 'ascomponent', 'promise-one', component, done
+      it 'should send to OUT port', (done) ->
+        wrapped = noflo.asCallback 'ascomponent/promise-one',
+          loader: loader
+        wrapped 'World', (err, res) ->
+          return done err if err
+          chai.expect(res).to.equal 'Hello World'
+          done()
+    describe 'with a rejected promise', ->
+      func = (hello) ->
+        return new Promise (resolve, reject) ->
+          setTimeout ->
+            reject new Error "Hello #{hello}"
+          , 5
+      it 'should be possible to componentize', (done) ->
+        component = -> noflo.asComponent func
+        loader.registerComponent 'ascomponent', 'sync-throw', component, done
+      it 'should send to ERROR port', (done) ->
+        wrapped = noflo.asCallback 'ascomponent/sync-throw',
+          loader: loader
+        wrapped 'Error', (err) ->
+          chai.expect(err).to.be.an 'error'
+          chai.expect(err.message).to.equal 'Hello Error'
+          done()

--- a/spec/AsComponent.coffee
+++ b/spec/AsComponent.coffee
@@ -107,6 +107,8 @@ describe 'asComponent interface', ->
             out: 'Hei Maailma'
           done()
     describe 'with a default value', ->
+      before ->
+        @skip() if isBrowser
       func = (name, greeting = 'Hello') ->
         return "#{greeting} #{name}"
       it 'should be possible to componentize', (done) ->
@@ -137,8 +139,7 @@ describe 'asComponent interface', ->
   describe 'with a function returning a Promise', ->
     describe 'with a resolved promise', ->
       before ->
-        if isBrowser and typeof window.Promise is 'undefined'
-          return @skip()
+        @skip() if isBrowser and typeof window.Promise is 'undefined'
       func = (hello) ->
         return new Promise (resolve, reject) ->
           setTimeout ->

--- a/spec/AsComponent.coffee
+++ b/spec/AsComponent.coffee
@@ -116,6 +116,26 @@ describe 'asComponent interface', ->
           chai.expect(err).to.be.an 'error'
           chai.expect(err.message).to.equal 'Hello Error'
           done()
+  describe 'with a synchronous function taking zero parameters', ->
+    describe 'with returned value', ->
+      func = () ->
+        return "Hello there"
+      it 'should be possible to componentize', (done) ->
+        component = -> noflo.asComponent func
+        loader.registerComponent 'ascomponent', 'sync-zero', component, done
+      it 'should contain correct ports', (done) ->
+        loader.load 'ascomponent/sync-zero', (err, instance) ->
+          return done err if err
+          chai.expect(Object.keys(instance.inPorts.ports)).to.eql ['in']
+          chai.expect(Object.keys(instance.outPorts.ports)).to.eql ['out', 'error']
+          done()
+      it 'should send to OUT port', (done) ->
+        wrapped = noflo.asCallback 'ascomponent/sync-zero',
+          loader: loader
+        wrapped 'bang', (err, res) ->
+          return done err if err
+          chai.expect(res).to.equal 'Hello there'
+          done()
   describe 'with an asynchronous function taking a single parameter and callback', ->
     describe 'with successful callback', ->
       func = (hello, callback) ->

--- a/spec/AsComponent.coffee
+++ b/spec/AsComponent.coffee
@@ -106,6 +106,34 @@ describe 'asComponent interface', ->
           chai.expect(res).to.eql
             out: 'Hei Maailma'
           done()
+    describe 'with a default value', ->
+      func = (name, greeting = 'Hello') ->
+        return "#{greeting} #{name}"
+      it 'should be possible to componentize', (done) ->
+        component = -> noflo.asComponent func
+        loader.registerComponent 'ascomponent', 'sync-default', component, done
+      it 'should be loadable', (done) ->
+        loader.load 'ascomponent/sync-default', done
+      it 'should contain correct ports', (done) ->
+        loader.load 'ascomponent/sync-default', (err, instance) ->
+          return done err if err
+          chai.expect(Object.keys(instance.inPorts.ports)).to.eql ['name', 'greeting']
+          chai.expect(Object.keys(instance.outPorts.ports)).to.eql ['out', 'error']
+          chai.expect(instance.inPorts.name.isRequired()).to.equal true
+          chai.expect(instance.inPorts.name.hasDefault()).to.equal false
+          chai.expect(instance.inPorts.greeting.isRequired()).to.equal false
+          chai.expect(instance.inPorts.greeting.hasDefault()).to.equal true
+          done()
+      it 'should send to OUT port', (done) ->
+        wrapped = noflo.asCallback 'ascomponent/sync-default',
+          loader: loader
+        wrapped
+          name: 'Maailma'
+        , (err, res) ->
+          return done err if err
+          chai.expect(res).to.eql
+            out: 'Hello Maailma'
+          done()
   describe 'with a function returning a Promise', ->
     describe 'with a resolved promise', ->
       before ->

--- a/src/lib/AsCallback.coffee
+++ b/src/lib/AsCallback.coffee
@@ -94,11 +94,6 @@ runNetwork = (network, inputs, options, callback) ->
   # Prepare inports
   inPorts = Object.keys network.graph.inports
   inSockets = {}
-  inPorts.forEach (inport) ->
-    portDef = network.graph.inports[inport]
-    process = network.getNode portDef.process
-    inSockets[inport] = internalSocket.createSocket()
-    process.component.inPorts[portDef.port].attach inSockets[inport]
   # Subscribe outports
   received = []
   outPorts = Object.keys network.graph.outports
@@ -129,6 +124,11 @@ runNetwork = (network, inputs, options, callback) ->
     # Send inputs
     for inputMap in inputs
       for port, value of inputMap
+        unless inSockets[port]
+          portDef = network.graph.inports[port]
+          process = network.getNode portDef.process
+          inSockets[port] = internalSocket.createSocket()
+          process.component.inPorts[portDef.port].attach inSockets[port]
         if IP.isIP value
           inSockets[port].post value
           continue

--- a/src/lib/AsCallback.coffee
+++ b/src/lib/AsCallback.coffee
@@ -1,5 +1,5 @@
 #     NoFlo - Flow-Based Programming for JavaScript
-#     (c) 2017 Flowhub UG
+#     (c) 2017-2018 Flowhub UG
 #     NoFlo may be freely distributed under the MIT license
 ComponentLoader = require('./ComponentLoader').ComponentLoader
 Network = require('./Network').Network

--- a/src/lib/AsComponent.coffee
+++ b/src/lib/AsComponent.coffee
@@ -27,6 +27,23 @@ getParams = require 'get-function-params'
 #         description: 'Generate a random number',
 #       });
 #     };
+#
+# ### Wrapping built-in functions
+#
+# Built-in JavaScript functions don't make their arguments introspectable. Because of this, these
+# cannot be directly converted to components. You'll have to provide a wrapper JavaScript function to make
+# the arguments appear as ports.
+#
+# Example:
+#
+#     exports.getComponent = function () {
+#       return noflo.asComponent(function (selector) {
+#         return document.querySelector(selector);
+#       }, {
+#         description: 'Return an element matching the CSS selector',
+#         icon: 'html5',
+#       });
+#     };
 exports.asComponent = (func, options) ->
   hasCallback = false
   params = getParams(func).filter (p) ->

--- a/src/lib/AsComponent.coffee
+++ b/src/lib/AsComponent.coffee
@@ -10,7 +10,12 @@ exports.asComponent = (func, options) ->
 
   c = new Component options
   for p in params
-    c.inPorts.add p.param
+    portOptions =
+      required: true
+    unless typeof p.default is 'undefined'
+      portOptions.default = p.default
+      portOptions.required = false
+    c.inPorts.add p.param, portOptions
     c.forwardBrackets[p.param] = ['out', 'error']
   unless params.length
     c.inPorts.add 'in',

--- a/src/lib/AsComponent.coffee
+++ b/src/lib/AsComponent.coffee
@@ -1,6 +1,29 @@
+#     NoFlo - Flow-Based Programming for JavaScript
+#     (c) 2018 Flowhub UG
+#     NoFlo may be freely distributed under the MIT license
 getParams = require 'get-function-params'
 {Component} = require './Component'
 
+# ## asComponent generator API
+#
+# asComponent is a helper for turning JavaScript functions into
+# NoFlo components.
+#
+# Each call to this function returns a component instance where
+# the input parameters of the given function are converted into
+# NoFlo inports, and there are `out` and `error` ports for the
+# results of the function execution.
+#
+# Variants supported:
+#
+# * Regular synchronous functions: return value gets sent to `out`. Thrown errors get sent to `error`
+# * Functions returning a Promise: resolved promises get sent to `out`, rejected promises to `error`
+# * Functions taking a Node.js style asynchronous callback: `err` argument to callback gets sent to `error`, result gets sent to `out`
+#
+# Usage example:
+#
+#     exports.getComponent = -> noflo.asComponent Math.random,
+#       description: 'Create a random number'
 exports.asComponent = (func, options) ->
   hasCallback = false
   params = getParams(func).filter (p) ->
@@ -35,6 +58,7 @@ exports.asComponent = (func, options) ->
       values = []
 
     if hasCallback
+      # Handle Node.js style async functions
       values.push (err, res) ->
         return output.done err if err
         output.sendDone res

--- a/src/lib/AsComponent.coffee
+++ b/src/lib/AsComponent.coffee
@@ -11,6 +11,7 @@ exports.asComponent = (func, options) ->
   c = new Component options
   for p in params
     c.inPorts.add p.param
+    c.forwardBrackets[p.param] = ['out', 'error']
   unless params.length
     c.inPorts.add 'in',
       datatype: 'bang'

--- a/src/lib/AsComponent.coffee
+++ b/src/lib/AsComponent.coffee
@@ -10,17 +10,23 @@ exports.asComponent = (func, options) ->
 
   c = new Component options
   for p in params
-    if p.param is 'callback'
-      hasCallback = true
-      continue
     c.inPorts.add p.param
+  unless params.length
+    c.inPorts.add 'in',
+      datatype: 'bang'
+
   c.outPorts.add 'out'
   c.outPorts.add 'error'
   c.process (input, output) ->
-    for p in params
-      return unless input.hasData p.param
-    values = params.map (p) ->
-      input.getData p.param
+    if params.length
+      for p in params
+        return unless input.hasData p.param
+      values = params.map (p) ->
+        input.getData p.param
+    else
+      return unless input.hasData 'in'
+      input.getData 'in'
+      values = []
 
     if hasCallback
       values.push (err, res) ->

--- a/src/lib/AsComponent.coffee
+++ b/src/lib/AsComponent.coffee
@@ -22,8 +22,11 @@ getParams = require 'get-function-params'
 #
 # Usage example:
 #
-#     exports.getComponent = -> noflo.asComponent Math.random,
-#       description: 'Create a random number'
+#     exports.getComponent = function () {
+#       return noflo.asComponent(Math.random, {
+#         description: 'Generate a random number',
+#       });
+#     };
 exports.asComponent = (func, options) ->
   hasCallback = false
   params = getParams(func).filter (p) ->

--- a/src/lib/AsComponent.coffee
+++ b/src/lib/AsComponent.coffee
@@ -1,0 +1,25 @@
+getParams = require 'get-function-params'
+{Component} = require './Component'
+
+exports.asComponent = (func, options) ->
+  params = getParams func
+  c = new Component options
+  for p in params
+    c.inPorts.add p.param
+  c.outPorts.add 'out'
+  c.outPorts.add 'error'
+  c.process (input, output) ->
+    for p in params
+      return unless input.hasData p.param
+    values = params.map (p) ->
+      input.getData p.param
+    res = func.apply null, values
+    if typeof res is 'object' and typeof res.then is 'function'
+      # Result is a Promise, resolve and handle
+      res.then (val) ->
+        output.sendDone val
+      , (err) ->
+        output.done err
+      return
+    output.sendDone res
+  c

--- a/src/lib/AsComponent.coffee
+++ b/src/lib/AsComponent.coffee
@@ -44,6 +44,14 @@ getParams = require 'get-function-params'
 #         icon: 'html5',
 #       });
 #     };
+#
+# ### Default values
+#
+# Function arguments with a default value are supported in ES6 environments. The default arguments are visible via the component's
+# port interface.
+#
+# However, ES5 transpilation doesn't work with default values. In these cases the port with a default won't be visible. It is
+# recommended to use default values only with components that don't need to run in legacy browsers.
 exports.asComponent = (func, options) ->
   hasCallback = false
   params = getParams(func).filter (p) ->

--- a/src/lib/NoFlo.coffee
+++ b/src/lib/NoFlo.coffee
@@ -1,5 +1,5 @@
 #     NoFlo - Flow-Based Programming for JavaScript
-#     (c) 2013-2017 Flowhub UG
+#     (c) 2013-2018 Flowhub UG
 #     (c) 2011-2012 Henri Bergius, Nemein
 #     NoFlo may be freely distributed under the MIT license
 #
@@ -177,5 +177,13 @@ exports.asCallback = require('./AsCallback').asCallback
 
 # ## Generating components from JavaScript functions
 #
+# The `asComponent` helper makes it easy to expose a JavaScript function as a
+# NoFlo component. All input arguments become input ports, and the function's
+# result will be sent to either `out` or `error` port.
 #
+#     exports.getComponent = function () {
+#       return noflo.asComponent(Math.random, {
+#         description: 'Generate a random number',
+#       });
+#     };
 exports.asComponent = require('./AsComponent').asComponent

--- a/src/lib/NoFlo.coffee
+++ b/src/lib/NoFlo.coffee
@@ -174,3 +174,8 @@ exports.saveFile = (graph, file, callback) ->
 #       // Do something with results
 #     });
 exports.asCallback = require('./AsCallback').asCallback
+
+# ## Generating components from JavaScript functions
+#
+#
+exports.asComponent = require('./AsComponent').asComponent


### PR DESCRIPTION
* [x] Implement `noflo.asComponent = (func, options) => {}`
* [x] Handle synchronous functions returning a value
* [x] Handle functions returning a Promise
* [x] Handle Node.js style functions with a `callback` param
* [x] Handle functions without parameters with a single bang port
* [x] Set up bracket forwarding
* [x] Expose parameter default values on component level
* [x] Document the interface

Fixes #590 