### PR TITLE
Skip coffee coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-- '8'
+- 'lts/*'
 after_success:
 - ./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls
 deploy:

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -71,7 +71,6 @@ module.exports = ->
           reporter: 'spec'
           require: [
             'coffeescript/register'
-            'coffee-coverage/register-istanbul'
           ]
           grep: process.env.TESTS
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "babel-loader": "^7.1.2",
     "babel-preset-es2015": "^6.24.1",
     "chai": "^4.0.0",
-    "coffee-coverage": "^3.0.0",
     "coveralls": "^3.0.0",
     "grunt": "^1.0.1",
     "grunt-cli": "^1.2.0",
@@ -52,7 +51,6 @@
   },
   "scripts": {
     "test": "nyc grunt test",
-    "posttest": "nyc check-coverage --lines 75",
     "build": "grunt build"
   },
   "docco_husky": {


### PR DESCRIPTION
Right now build is broken due to benbria/coffee-coverage#93

This removes test coverage reporting. Possible next steps would be either to:

* Wait for coffee-coverage to be fixed (and hope no further issues arise)
* Decaffeinate NoFlo