### PR TITLE
Provide access to Network instance via AsCallback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ NoFlo ChangeLog
 * Added support for a more standard `noflo.createNetwork(graph, options, callback)` signature, with backwards compatibility for the legacy `noflo.createNetwork(graph, callback, options)` signature
 * Removed support for `noflo.WirePattern`. WirePattern has been deprecated since 1.0, and all code using it should be migrated to the latest Process API
 * Removed support for changing component icon and description statically (on class level) at run-time (i.e. `ComponentName::icon = 'new-icon'`). Component icon and description should be set in class constructor or in `getComponent` instead. Changing icon and description for a specific instance (process) is not affected and is fully supported
+* Added optional `networkCallback` option for `noflo.asCallback` to provide access to the network instance for debugging purposes
 
 ## 1.1.3 (April 12th 2018)
 

--- a/spec/AsCallback.js
+++ b/spec/AsCallback.js
@@ -456,4 +456,58 @@ Async(process/Async) OUT -> IN Values(process/Values)\
       });
     });
   });
+  describe('with networkCallback option', () => {
+    let wrapped = null;
+    let called = 0;
+    let started = 0;
+    afterEach(() => {
+      called = 0;
+      started = 0;
+    });
+    it('should not provide network at callbackization time', (done) => {
+      chai.expect(called).to.equal(0);
+      wrapped = noflo.asCallback('process/Async', {
+        loader,
+        networkCallback: (network) => {
+          network.on('start', () => {
+            started++;
+          });
+          called++;
+        },
+      });
+      chai.expect(wrapped).to.be.a('function');
+      chai.expect(called).to.equal(0);
+      done();
+    });
+    it('should provide the network to the callback when executed', (done) => {
+      const expected = { hello: 'world' };
+      chai.expect(called).to.equal(0);
+
+      wrapped(expected, (err, out) => {
+        if (err) {
+          done(err);
+          return;
+        }
+        chai.expect(out).to.eql(expected);
+        chai.expect(called).to.equal(1);
+        done();
+      });
+    });
+    it('should provide the network before actual execution so that we catch the start event', (done) => {
+      const expected = { hello: 'world' };
+      chai.expect(called).to.equal(0);
+      chai.expect(started).to.equal(0);
+
+      wrapped(expected, (err, out) => {
+        if (err) {
+          done(err);
+          return;
+        }
+        chai.expect(out).to.eql(expected);
+        chai.expect(called).to.equal(1);
+        chai.expect(started).to.equal(1);
+        done();
+      });
+    });
+  });
 });

--- a/src/lib/AsCallback.js
+++ b/src/lib/AsCallback.js
@@ -323,6 +323,9 @@ exports.asCallback = function asCallback(component, options) {
         callback(err);
         return;
       }
+      if (options.networkCallback) {
+        options.networkCallback(network);
+      }
       const resultType = getType(inputs, network);
       const inputMap = prepareInputMap(inputs, resultType, network);
       runNetwork(network, inputMap, options, (err2, outputMap) => {


### PR DESCRIPTION
Allows instrumenting `asCallback`-wrapped NoFlo runs with Flowtrace etc.