### PR TITLE
Unbundle CoffeeScript

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 NoFlo ChangeLog
 ===============
 
+## 1.3.0 (git master)
+
+* CoffeeScript is no longer bundled with NoFlo. Install the CoffeeScript compiler in your project if you need to be able to load CoffeeScript components
+
 ## 1.2.7 (November 13th 2020)
 
 * Added safeties against trying to load a falsy graph in `asCallback`

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "node": ">= 6"
   },
   "dependencies": {
-    "coffeescript": "^2.2.1",
     "debug": "^4.0.1",
     "fbp": "^1.5.0",
     "fbp-graph": "^0.6.1",
@@ -27,6 +26,7 @@
     "@babel/preset-env": "^7.11.0",
     "@types/node": "^14.14.2",
     "chai": "^4.0.0",
+    "coffeescript": "^2.2.1",
     "coveralls": "^3.0.0",
     "eslint": "^7.7.0",
     "eslint-config-airbnb-base": "^14.2.0",

--- a/src/lib/loader/NodeJs.js
+++ b/src/lib/loader/NodeJs.js
@@ -14,11 +14,8 @@ const utils = require('../Utils');
 // Type loading CoffeeScript compiler
 let CoffeeScript;
 try {
-  // eslint-disable-next-line import/no-unresolved
+  // eslint-disable-next-line import/no-unresolved,import/no-extraneous-dependencies
   CoffeeScript = require('coffeescript');
-  if (typeof CoffeeScript.register !== 'undefined') {
-    CoffeeScript.register();
-  }
 } catch (e) {
   // If there is no CoffeeScript compiler installed, we simply don't support compiling
 }
@@ -314,8 +311,8 @@ function registerModules(loader, modules, callback) {
 
     return Promise.all(m.components.map((c) => new Promise((resolve, reject) => {
       const language = utils.guessLanguageFromFilename(c.path);
-      if (language === 'typescript') {
-        // We can't require a TypeScript module, go the setSource route
+      if (language === 'typescript' || language === 'coffeescript') {
+        // We can't require a module that requires transpilation, go the setSource route
         fs.readFile(path.resolve(loader.baseDir, c.path), 'utf-8', (fsErr, source) => {
           if (fsErr) {
             reject(fsErr);


### PR DESCRIPTION
With this PR, untranspiled CoffeeScript components will be only loadable if the `coffeescript` module is installed in the project. Essentially they'll be treated the same way as TypeScript.