### PR TITLE
Integrate Flowtrace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,19 @@ NoFlo ChangeLog
 
 ## 1.3.0 (git master)
 
+* NoFlo `createNetwork` and `asCallback` now accept a `flowtrace` option to pass a [Flowtrace instance](https://github.com/flowbased/flowtrace) for retroactive debugging. Example:
+
+```javascript
+const { Flowtrace } = require('flowtrace');
+const tracer = new Flowtrace();
+noflo.createNetwork(myGraph, {
+  flowtrace: tracer,
+}, (err, network) => {
+  // ...
+  console.log(tracer.toJSON());
+});
+```
+
 * NoFlo `createNetwork` now defaults to the non-legacy "network drives graph" mode
 * NoFlo `createNetwork` now only supports the `graph, options, callback` signature, no options given in some other order
 * `noflo.Network` interface has been removed. Use `createNetwork` to instantiate networks

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "fbp": "^1.5.0",
     "fbp-graph": "^0.6.1",
     "fbp-manifest": "^0.2.5",
-    "flowtrace": "^0.1.2",
     "get-function-params": "^2.0.6"
   },
   "devDependencies": {
@@ -33,6 +32,7 @@
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-plugin-import": "^2.22.0",
     "events": "^3.2.0",
+    "flowtrace": "^0.1.2",
     "karma": "^5.1.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "debug": "^4.0.1",
     "fbp": "^1.5.0",
-    "fbp-graph": "^0.6.1",
+    "fbp-graph": "^0.6.2",
     "fbp-manifest": "^0.2.5",
     "get-function-params": "^2.0.6"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "fbp": "^1.5.0",
     "fbp-graph": "^0.6.1",
     "fbp-manifest": "^0.2.5",
+    "flowtrace": "^0.1.2",
     "get-function-params": "^2.0.6"
   },
   "devDependencies": {

--- a/spec/fixtures/entry.js
+++ b/spec/fixtures/entry.js
@@ -1,5 +1,6 @@
-var exported = {
-  noflo: require('../../lib/NoFlo')
+const exported = {
+  noflo: require('../../lib/NoFlo'),
+  flowtrace: require('flowtrace'),
 };
 
 if (window) {
@@ -7,7 +8,6 @@ if (window) {
     if (exported[moduleName]) {
       return exported[moduleName];
     }
-    throw new Error('Module ' + moduleName + ' not available');
+    throw new Error(`Module '${moduleName}' not available`);
   };
 }
-

--- a/spec/utils/inject.js
+++ b/spec/utils/inject.js
@@ -4,9 +4,11 @@ if (typeof global !== 'undefined') {
   global.chai = require('chai');
   global.path = require('path');
   global.noflo = require('../../src/lib/NoFlo');
+  global.flowtrace = require('flowtrace');
   global.baseDir = process.cwd();
 } else {
   // Browser injections for Mocha tests
   window.noflo = require('noflo');
   window.baseDir = 'browser';
+  window.flowtrace = require('flowtrace');
 }

--- a/src/lib/AsCallback.js
+++ b/src/lib/AsCallback.js
@@ -134,6 +134,7 @@ function runNetwork(network, inputs, options, callback) {
     const portDef = network.graph.outports[outport];
     const process = network.getNode(portDef.process);
     outSockets[outport] = internalSocket.createSocket();
+    network.subscribeSocket(outSockets[outport]);
     process.component.outPorts[portDef.port].attach(outSockets[outport]);
     outSockets[outport].from = {
       process,
@@ -187,6 +188,11 @@ function runNetwork(network, inputs, options, callback) {
           }
           const process = network.getNode(portDef.process);
           inSockets[port] = internalSocket.createSocket();
+          network.subscribeSocket(inSockets[port]);
+          inSockets[port].to = {
+            process,
+            port,
+          };
           process.component.inPorts[portDef.port].attach(inSockets[port]);
         }
         try {

--- a/src/lib/BaseNetwork.js
+++ b/src/lib/BaseNetwork.js
@@ -922,6 +922,14 @@ class BaseNetwork extends EventEmitter {
         type: 'noflo',
       });
       this.trace.addGraph(this.graph.name, this.graph, true);
+      Object.keys(this.processes).forEach((nodeId) => {
+        // Register existing subgraphs
+        const node = this.processes[nodeId];
+        if (!node.component.isSubgraph() || !node.component.network) {
+          return;
+        }
+        this.trace.addGraph(node.componentName, node.component.network.graph, false);
+      });
       return;
     }
     this.trace = null;

--- a/src/lib/BaseNetwork.js
+++ b/src/lib/BaseNetwork.js
@@ -152,6 +152,10 @@ class BaseNetwork extends EventEmitter {
     if (!this.flowtrace) {
       return;
     }
+    if (this.flowtraceName && this.flowtraceName !== this.flowtrace.mainGraph) {
+      // Let main graph log all events from subgraphs
+      return;
+    }
     switch (event) {
       case 'ip': {
         let type = 'data';

--- a/src/lib/BaseNetwork.js
+++ b/src/lib/BaseNetwork.js
@@ -91,8 +91,8 @@ class BaseNetwork extends EventEmitter {
     this.defaults = [];
     // The Graph this network is instantiated with
     this.graph = graph;
-    // Flowtrace for this network, when available
-    this.trace = null;
+    // Enable Flowtrace for this network, when available
+    this.setTrace(options.flowtrace || false);
     this.started = false;
     this.stopped = true;
     this.debug = true;
@@ -377,6 +377,7 @@ class BaseNetwork extends EventEmitter {
     }
 
     if (this.trace) {
+      // FIXME: This doesn't handle registration for sub-subgraphs
       this.trace.addGraph(node.componentName, node.component.network.graph, false);
     }
 

--- a/src/lib/BaseNetwork.js
+++ b/src/lib/BaseNetwork.js
@@ -913,6 +913,7 @@ class BaseNetwork extends EventEmitter {
   setFlowtrace(flowtrace, name = null, main = true) {
     if (!flowtrace) {
       this.flowtrace = null;
+      return;
     }
     if (this.flowtrace) {
       // We already have a tracer

--- a/src/lib/NoFlo.js
+++ b/src/lib/NoFlo.js
@@ -99,6 +99,8 @@ exports.IP = require('./IP');
 //
 // * `delay`: (default: FALSE) Whether the network should be started later. Defaults to
 //   immediate execution
+// * `flowtrace`: (default: NULL) Flowtrace instance to create a retroactive debugging
+//   trace of the network run.
 // * `subscribeGraph`: (default: FALSE) Whether the network should monitor the underlying
 //   graph for changes
 //


### PR DESCRIPTION
* [x] Allow passing a Flowtracer via network options
* [x] Add network graph and all subgraphs (including ones loaded later)
* [x] Register all network events with the Flowtrace file
* [x] Add tests for Flowtrace in base networks, and when used via `asCallback`

Fixes #536 