### PR TITLE
Build module with tsc

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+lib/
+components/
+browser/

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
-node_modules/
-lib/
-components/
-browser/
+/node_modules/
+/lib/
+/components/
+/browser/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,6 @@ jobs:
         with:
           node-version: 12
       - run: npm install
-      - run: npm run build
       - run: npm test
 
   publish-npm:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm install
-    - run: npm run build
     - run: npm test
       env:
         CI: true

--- a/bin/noflo-cache-preheat
+++ b/bin/noflo-cache-preheat
@@ -1,49 +1,49 @@
 #!/usr/bin/env node
 // vim: set filetype=javascript:
-var noflo = require('../lib/NoFlo');
-var path = require('path');
-var fs = require('fs');
+const path = require('path');
+const fs = require('fs');
+const noflo = require('../lib/NoFlo');
 
 // Base setup
-var baseDir = process.cwd();
-var cacheFile = path.resolve(baseDir, 'fbp.json');
+const baseDir = process.cwd();
+const cacheFile = path.resolve(baseDir, 'fbp.json');
 
-var preheat = function (callback) {
-  console.log("Pre-heating NoFlo cache with manifest for " + baseDir);
-  var loader = new noflo.ComponentLoader(baseDir, {
+function preheat(callback) {
+  console.log(`Pre-heating NoFlo cache with manifest for ${baseDir}`);
+  const loader = new noflo.ComponentLoader(baseDir, {
     cache: true,
-    discover: true
+    discover: true,
   });
   console.time('NPM traversal for NoFlo components');
-  loader.listComponents(function (err, components) {
+  loader.listComponents((err, components) => {
     console.timeEnd('NPM traversal for NoFlo components');
     callback(err, components);
   });
-};
+}
 
-var reportAndVerify = function (err, components) {
+function reportAndVerify(err, components) {
   if (err) {
     console.log(err);
     process.exit(1);
   }
-  console.log("Found " + (Object.keys(components).length) + " components.");
-  fs.stat(cacheFile, function (err, stats) {
-    if (err) {
-      console.log(err.message);
+  console.log(`Found ${Object.keys(components).length} components.`);
+  fs.stat(cacheFile, (statErr) => {
+    if (statErr) {
+      console.log(statErr.message);
       process.exit(1);
     }
     return process.exit(0);
   });
-};
+}
 
-fs.stat(cacheFile, function (err, stats) {
+fs.stat(cacheFile, (err) => {
   if (err) {
-    return preheat(reportAndVerify);
+    preheat(reportAndVerify);
   }
-  console.log('Old cache file ' + cacheFile + ' found, clearing');
-  fs.unlink(cacheFile, function (err) {
-    if (err) {
-      console.log(err);
+  console.log(`Old cache file ${cacheFile} found, clearing`);
+  fs.unlink(cacheFile, (unlinkErr) => {
+    if (unlinkErr) {
+      console.log(unlinkErr);
       process.exit(1);
     }
     preheat(reportAndVerify);

--- a/bin/noflo-cache-preheat
+++ b/bin/noflo-cache-preheat
@@ -39,6 +39,7 @@ function reportAndVerify(err, components) {
 fs.stat(cacheFile, (err) => {
   if (err) {
     preheat(reportAndVerify);
+    return;
   }
   console.log(`Old cache file ${cacheFile} found, clearing`);
   fs.unlink(cacheFile, (unlinkErr) => {

--- a/examples/http/HelloController.js
+++ b/examples/http/HelloController.js
@@ -1,14 +1,15 @@
-const noflo = require("noflo");
+// eslint-disable-next-line import/no-unresolved
+const noflo = require('noflo');
 
 exports.getComponent = () => {
-  const c = new noflo.Component;
-  c.description = "Simple controller that says hello, user";
+  const c = new noflo.Component();
+  c.description = 'Simple controller that says hello, user';
   c.inPorts.add('in',
-    {datatype: 'object'});
+    { datatype: 'object' });
   c.outPorts.add('out',
-    {datatype: 'object'});
+    { datatype: 'object' });
   c.outPorts.add('data',
-    {datatype: 'object'});
+    { datatype: 'object' });
   c.process((input, output) => {
     if (!input.hasData('in')) { return; }
     const request = input.getData('in');
@@ -16,9 +17,9 @@ exports.getComponent = () => {
       out: request,
       data: {
         locals: {
-          string: `Hello, ${request.req.remoteUser}`
-        }
-      }
+          string: `Hello, ${request.req.remoteUser}`,
+        },
+      },
     });
   });
   return c;

--- a/examples/http/hello.js
+++ b/examples/http/hello.js
@@ -31,6 +31,7 @@ graph.addEdge('Render', 'out', 'Write Response', 'string');
 
 noflo.createNetwork(graph, (err) => {
   if (err) {
+    // eslint-disable-next-line no-console
     console.error(err);
     process.exit(1);
   }

--- a/examples/http/hello.js
+++ b/examples/http/hello.js
@@ -1,31 +1,33 @@
 // Flow-based example of serving web pages
 
-const noflo = require("noflo");
+// eslint-disable-next-line import/no-unresolved
+const noflo = require('noflo');
 
-const graph = noflo.graph.createGraph("blog");
+const graph = noflo.graph.createGraph('blog');
 
-graph.addNode("Web Server", "HTTP/Server");
-graph.addNode("Profiler", "HTTP/Profiler");
-graph.addNode("Authentication", "HTTP/BasicAuth");
-graph.addNode("Read Template", "ReadFile");
-graph.addNode("Greet User", require("./HelloController").getComponent());
-graph.addNode("Render", "Template");
-graph.addNode("Write Response", "HTTP/WriteResponse");
-graph.addNode("Send", "HTTP/SendResponse");
+graph.addNode('Web Server', 'HTTP/Server');
+graph.addNode('Profiler', 'HTTP/Profiler');
+graph.addNode('Authentication', 'HTTP/BasicAuth');
+graph.addNode('Read Template', 'ReadFile');
+graph.addNode('Greet User', require('./HelloController').getComponent());
+
+graph.addNode('Render', 'Template');
+graph.addNode('Write Response', 'HTTP/WriteResponse');
+graph.addNode('Send', 'HTTP/SendResponse');
 
 // Main request flow
-graph.addInitial(8003, "Web Server", "listen");
-graph.addEdge("Web Server", "request", "Profiler", "in");
-graph.addEdge("Profiler", "out", "Authentication", "in");
-graph.addEdge("Authentication", "out", "Greet User", "in");
-graph.addEdge("Greet User", "out", "Write Response", "in");
-graph.addEdge("Greet User", "data", "Render", "options");
-graph.addEdge("Write Response", "out", "Send", "in");
+graph.addInitial(8003, 'Web Server', 'listen');
+graph.addEdge('Web Server', 'request', 'Profiler', 'in');
+graph.addEdge('Profiler', 'out', 'Authentication', 'in');
+graph.addEdge('Authentication', 'out', 'Greet User', 'in');
+graph.addEdge('Greet User', 'out', 'Write Response', 'in');
+graph.addEdge('Greet User', 'data', 'Render', 'options');
+graph.addEdge('Write Response', 'out', 'Send', 'in');
 
 // Templating flow
-graph.addInitial(`${__dirname}/hello.jade`, "Read Template", "in");
-graph.addEdge("Read Template", "out", "Render", "template");
-graph.addEdge("Render", "out", "Write Response", "string");
+graph.addInitial(`${__dirname}/hello.jade`, 'Read Template', 'in');
+graph.addEdge('Read Template', 'out', 'Render', 'template');
+graph.addEdge('Render', 'out', 'Write Response', 'string');
 
 noflo.createNetwork(graph, (err) => {
   if (err) {

--- a/examples/linecount/count.js
+++ b/examples/linecount/count.js
@@ -1,7 +1,8 @@
 // Flow-based example of counting lines of a file, roughly equivalent to
 // "wc -l <filename>"
 
-const noflo = require('../../lib/NoFlo');
+// eslint-disable-next-line import/no-unresolved
+const noflo = require('noflo');
 
 if (!process.argv[2]) {
   // eslint-disable-next-line no-console

--- a/examples/linecount/count.js
+++ b/examples/linecount/count.js
@@ -4,6 +4,7 @@
 const noflo = require('../../lib/NoFlo');
 
 if (!process.argv[2]) {
+  // eslint-disable-next-line no-console
   console.error('You must provide a filename');
   process.exit(1);
 }
@@ -30,6 +31,7 @@ noflo.createNetwork(graph, {
   subscribeGraph: false,
 }, (err) => {
   if (err) {
+    // eslint-disable-next-line no-console
     console.error(err);
     process.exit(1);
   }

--- a/examples/linecount/count.js
+++ b/examples/linecount/count.js
@@ -1,30 +1,30 @@
 // Flow-based example of counting lines of a file, roughly equivalent to
 // "wc -l <filename>"
 
-const noflo = require("../../lib/NoFlo");
+const noflo = require('../../lib/NoFlo');
 
 if (!process.argv[2]) {
-  console.error("You must provide a filename");
+  console.error('You must provide a filename');
   process.exit(1);
 }
 
 const fileName = process.argv[2];
 
-const graph = noflo.graph.createGraph("linecount");
-graph.addNode("Read File", "filesystem/ReadFile");
-graph.addNode("Split by Lines", "strings/SplitStr");
-graph.addNode("Count Lines", "packets/Counter");
-graph.addNode("Display", "core/Output");
+const graph = noflo.graph.createGraph('linecount');
+graph.addNode('Read File', 'filesystem/ReadFile');
+graph.addNode('Split by Lines', 'strings/SplitStr');
+graph.addNode('Count Lines', 'packets/Counter');
+graph.addNode('Display', 'core/Output');
 
-graph.addEdge("Read File", "out", "Split by Lines", "in");
-//graph.addEdge "Read File", "error", "Display", "in"
-graph.addEdge("Split by Lines", "out", "Count Lines", "in");
-graph.addEdge("Count Lines", "count", "Display", "in");
+graph.addEdge('Read File', 'out', 'Split by Lines', 'in');
+// graph.addEdge "Read File", "error", "Display", "in"
+graph.addEdge('Split by Lines', 'out', 'Count Lines', 'in');
+graph.addEdge('Count Lines', 'count', 'Display', 'in');
 // Specify encoding
-graph.addInitial("utf-8", "Read File", "encoding");
+graph.addInitial('utf-8', 'Read File', 'encoding');
 
 // Kick the process off by sending filename to fileReader
-graph.addInitial(fileName, "Read File", "in");
+graph.addInitial(fileName, 'Read File', 'in');
 
 noflo.createNetwork(graph, {
   subscribeGraph: false,

--- a/karma.config.js
+++ b/karma.config.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 module.exports = (config) => {
   const configuration = {
     basePath: process.cwd(),

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "debug": "^4.0.1",
     "fbp": "^1.5.0",
     "fbp-graph": "^0.6.2",
-    "fbp-manifest": "^0.2.5",
+    "fbp-manifest": "^0.2.7",
     "get-function-params": "^2.0.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
     "get-function-params": "^2.0.6"
   },
   "devDependencies": {
-    "@babel/cli": "^7.10.5",
-    "@babel/core": "^7.11.1",
-    "@babel/preset-env": "^7.11.0",
     "@types/node": "^14.14.2",
     "chai": "^4.0.0",
     "coffeescript": "^2.2.1",
@@ -59,13 +56,13 @@
     "url": "git://github.com/noflo/noflo.git"
   },
   "scripts": {
-    "lint": "eslint src",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "pretest": "npm run lint && npm run typecheck",
     "test:node": "nyc mocha --require spec/utils/inject.js spec",
     "test:browser": "karma start karma.config.js",
     "test": "npm run test:node && npm run test:browser",
-    "build:node": "babel src --out-dir .",
+    "build:node": "tsc",
     "build:browser": "webpack",
     "build": "npm run build:node && npm run build:browser"
   },
@@ -75,7 +72,9 @@
   },
   "nyc": {
     "include": [
-      "src/**/*.js"
+      "components/*.js",
+      "lib/*.js",
+      "lib/**/*.js"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "webpack-cli": "^4.0.0"
   },
   "main": "./lib/NoFlo",
+  "types": "./lib/NoFlo.d.ts",
   "bin": {
     "noflo": "./bin/noflo",
     "noflo-cache-preheat": "./bin/noflo-cache-preheat"

--- a/package.json
+++ b/package.json
@@ -58,13 +58,13 @@
   "scripts": {
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "pretest": "npm run lint && npm run typecheck",
-    "test:node": "nyc mocha --require spec/utils/inject.js spec",
-    "test:browser": "karma start karma.config.js",
-    "test": "npm run test:node && npm run test:browser",
     "build:node": "tsc",
     "build:browser": "webpack",
-    "build": "npm run build:node && npm run build:browser"
+    "build": "npm run build:node && npm run build:browser",
+    "pretest": "npm run lint && npm run typecheck && npm run build",
+    "test:node": "nyc mocha --require spec/utils/inject.js spec",
+    "test:browser": "karma start karma.config.js",
+    "test": "npm run test:node && npm run test:browser"
   },
   "docco_husky": {
     "output_dir": "docs",

--- a/package.json
+++ b/package.json
@@ -57,11 +57,10 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit",
     "build:node": "tsc",
     "build:browser": "webpack",
     "build": "npm run build:node && npm run build:browser",
-    "pretest": "npm run lint && npm run typecheck && npm run build",
+    "pretest": "npm run lint && npm run build",
     "test:node": "nyc mocha --require spec/utils/inject.js spec",
     "test:browser": "karma start karma.config.js",
     "test": "npm run test:node && npm run test:browser"

--- a/spec/ComponentLoader.js
+++ b/spec/ComponentLoader.js
@@ -928,7 +928,7 @@ describe('ComponentLoader with a fixture project', () => {
         done(err);
         return;
       }
-      chai.expect(source.tests).to.include('componentloader/Repeat')
+      chai.expect(source.tests).to.include('componentloader/Repeat');
       done();
     });
   });
@@ -960,7 +960,7 @@ describe('ComponentLoader with a fixture project', () => {
         done(err);
         return;
       }
-      chai.expect(source.tests).to.include('example/RepeatAsync')
+      chai.expect(source.tests).to.include('example/RepeatAsync');
       done();
     });
   });

--- a/spec/ComponentLoader.js
+++ b/spec/ComponentLoader.js
@@ -475,7 +475,7 @@ describe('ComponentLoader with no external packages installed', () => {
   describe('writing sources', () => {
     let localNofloPath;
     if (!noflo.isBrowser()) {
-      localNofloPath = JSON.stringify(path.resolve(__dirname, '../src/lib/NoFlo'));
+      localNofloPath = JSON.stringify(path.resolve(__dirname, '../lib/NoFlo'));
     }
     describe('with working code', () => {
       describe('with ES5', () => {

--- a/spec/fixtures/componentloader/components/Output.js
+++ b/spec/fixtures/componentloader/components/Output.js
@@ -1,4 +1,4 @@
-const noflo = require('../../../../src/lib/NoFlo');
+const noflo = require('../../../../lib/NoFlo');
 
 exports.getComponent = function () {
   const c = new noflo.Component();

--- a/spec/fixtures/componentloader/components/Repeat.ts
+++ b/spec/fixtures/componentloader/components/Repeat.ts
@@ -1,4 +1,4 @@
-import { Component } from '../../../../src/lib/NoFlo';
+import { Component } from '../../../../lib/NoFlo';
 
 exports.getComponent = (): Component => {
   const c = new Component();

--- a/spec/fixtures/componentloader/components/RepeatAsync.coffee
+++ b/spec/fixtures/componentloader/components/RepeatAsync.coffee
@@ -1,4 +1,4 @@
-noflo = require '../../../../src/lib/NoFlo'
+noflo = require '../../../../lib/NoFlo'
 
 exports.getComponent = () ->
   c = new noflo.Component()

--- a/spec/fixtures/componentloader/node_modules/example/components/Forward.js
+++ b/spec/fixtures/componentloader/node_modules/example/components/Forward.js
@@ -1,4 +1,4 @@
-const noflo = require('../../../../../../src/lib/NoFlo');
+const noflo = require('../../../../../../lib/NoFlo');
 
 exports.getComponent = function () {
   const c = new noflo.Component();

--- a/spec/fixtures/componentloader/node_modules/example/components/Repeat.ts
+++ b/spec/fixtures/componentloader/node_modules/example/components/Repeat.ts
@@ -1,4 +1,4 @@
-import { Component } from '../../../../../../src/lib/NoFlo';
+import { Component } from '../../../../../../lib/NoFlo';
 
 exports.getComponent = (): Component => {
   const c = new Component();

--- a/spec/fixtures/componentloader/node_modules/example/components/RepeatAsync.coffee
+++ b/spec/fixtures/componentloader/node_modules/example/components/RepeatAsync.coffee
@@ -1,4 +1,4 @@
-noflo = require '../../../../../../src/lib/NoFlo'
+noflo = require '../../../../../../lib/NoFlo'
 
 exports.getComponent = () ->
   c = new noflo.Component()

--- a/spec/fixtures/componentloader/node_modules/example/loader.js
+++ b/spec/fixtures/componentloader/node_modules/example/loader.js
@@ -1,4 +1,4 @@
-const noflo = require('../../../../../src/lib/NoFlo');
+const noflo = require('../../../../../lib/NoFlo');
 
 module.exports = function (loader, callback) {
   loader.registerComponent('example', 'Hello', () => {

--- a/spec/utils/inject.js
+++ b/spec/utils/inject.js
@@ -3,7 +3,7 @@ if (typeof global !== 'undefined') {
   // Node.js injections for Mocha tests
   global.chai = require('chai');
   global.path = require('path');
-  global.noflo = require('../../src/lib/NoFlo');
+  global.noflo = require('../../lib/NoFlo');
   global.flowtrace = require('flowtrace');
   global.baseDir = process.cwd();
 } else {

--- a/src/components/Graph.js
+++ b/src/components/Graph.js
@@ -6,9 +6,10 @@
 /* eslint-disable
     class-methods-use-this,
     import/no-unresolved,
+    import/prefer-default-export,
 */
 
-const noflo = require('../lib/NoFlo');
+import * as noflo from '../lib/NoFlo';
 
 // The Graph component is used to wrap NoFlo Networks into components inside
 // another network.
@@ -264,4 +265,6 @@ class Graph extends noflo.Component {
   }
 }
 
-exports.getComponent = (metadata) => new Graph(metadata);
+export function getComponent(metadata) {
+  return new Graph(metadata);
+}

--- a/src/lib/AsCallback.js
+++ b/src/lib/AsCallback.js
@@ -331,17 +331,20 @@ function sendOutputMap(outputs, resultType, options, callback) {
  * @callback ResultCallback
  * @param {Error | null} err
  * @param {any} [output]
+ * @returns {void}
  */
 
 /**
  * @callback NetworkAsCallback
  * @param {any} input
  * @param {ResultCallback} callback
+ * @returns void
  */
 
 /**
  * @callback NetworkCallback
  * @param {Network} network
+ * @returns void
  */
 
 /**

--- a/src/lib/AsCallback.js
+++ b/src/lib/AsCallback.js
@@ -4,18 +4,13 @@
 
 /* eslint-disable
     no-param-reassign,
+    import/prefer-default-export,
 */
-const {
-  Graph,
-} = require('fbp-graph');
-const {
-  ComponentLoader,
-} = require('./ComponentLoader');
-const {
-  Network,
-} = require('./Network');
-const IP = require('./IP');
-const internalSocket = require('./InternalSocket');
+import { Graph } from 'fbp-graph';
+import { ComponentLoader } from './ComponentLoader';
+import { Network } from './Network';
+import IP from './IP';
+import * as internalSocket from './InternalSocket';
 
 // ## asCallback embedding API
 //
@@ -332,7 +327,7 @@ function sendOutputMap(outputs, resultType, options, callback) {
   callback(null, result);
 }
 
-exports.asCallback = function asCallback(component, options) {
+export function asCallback(component, options) {
   if (!component) {
     throw new Error('No component or graph provided');
   }
@@ -357,4 +352,4 @@ exports.asCallback = function asCallback(component, options) {
       });
     });
   };
-};
+}

--- a/src/lib/AsCallback.js
+++ b/src/lib/AsCallback.js
@@ -327,6 +327,34 @@ function sendOutputMap(outputs, resultType, options, callback) {
   callback(null, result);
 }
 
+/**
+ * @callback ResultCallback
+ * @param {Error | null} err
+ * @param {any} [output]
+ */
+
+/**
+ * @callback NetworkAsCallback
+ * @param {any} input
+ * @param {ResultCallback} callback
+ */
+
+/**
+ * @callback NetworkCallback
+ * @param {Network} network
+ */
+
+/**
+ * @param {Graph | string} component - Graph or component to load
+ * @param {Object} options
+ * @param {string} [options.name] - Name for the wrapped network
+ * @param {ComponentLoader} [options.loader] - Component loader instance to use, if any
+ * @param {string} [options.baseDir] - Project base directory for component loading
+ * @param {Object} [options.flowtrace] - Flowtrace instance to use for tracing this network run
+ * @param {NetworkCallback} [options.networkCallback] - Access to Network instance
+ * @param {boolean} [options.raw] - Whether the callback should operate on raw noflo.IP objects
+ * @returns {NetworkAsCallback}
+ */
 export function asCallback(component, options) {
   if (!component) {
     throw new Error('No component or graph provided');

--- a/src/lib/AsComponent.js
+++ b/src/lib/AsComponent.js
@@ -1,8 +1,11 @@
 //     NoFlo - Flow-Based Programming for JavaScript
 //     (c) 2018 Flowhub UG
 //     NoFlo may be freely distributed under the MIT license
-const getParams = require('get-function-params');
-const { Component } = require('./Component');
+/* eslint-disable
+    import/prefer-default-export,
+*/
+import getParams from 'get-function-params';
+import { Component } from './Component';
 
 // ## asComponent generator API
 //
@@ -56,7 +59,7 @@ const { Component } = require('./Component');
 // However, ES5 transpilation doesn't work with default values.
 // In these cases the port with a default won't be visible. It is
 // recommended to use default values only with components that don't need to run in legacy browsers.
-exports.asComponent = function asComponent(func, options) {
+export function asComponent(func, options) {
   let hasCallback = false;
   const params = getParams(func).filter((p) => {
     if (p.param !== 'callback') { return true; }
@@ -118,4 +121,4 @@ exports.asComponent = function asComponent(func, options) {
     output.sendDone(res);
   });
   return c;
-};
+}

--- a/src/lib/AsComponent.js
+++ b/src/lib/AsComponent.js
@@ -4,7 +4,7 @@
 /* eslint-disable
     import/prefer-default-export,
 */
-import getParams from 'get-function-params';
+import * as getParams from 'get-function-params';
 import { Component } from './Component';
 
 // ## asComponent generator API

--- a/src/lib/AsComponent.js
+++ b/src/lib/AsComponent.js
@@ -59,6 +59,11 @@ import { Component } from './Component';
 // However, ES5 transpilation doesn't work with default values.
 // In these cases the port with a default won't be visible. It is
 // recommended to use default values only with components that don't need to run in legacy browsers.
+/**
+ * @param {Function} func
+ * @param {Object} options
+ * @returns {Component}
+ */
 export function asComponent(func, options) {
   let hasCallback = false;
   const params = getParams(func).filter((p) => {

--- a/src/lib/BaseNetwork.js
+++ b/src/lib/BaseNetwork.js
@@ -6,15 +6,15 @@
 /* eslint-disable
     no-param-reassign,
     no-underscore-dangle,
+    import/prefer-default-export,
 */
 
-const { EventEmitter } = require('events');
-const internalSocket = require('./InternalSocket');
-const platform = require('./Platform');
-const componentLoader = require('./ComponentLoader');
-const utils = require('./Utils');
-const IP = require('./IP');
-const { deprecated } = require('./Platform');
+import { EventEmitter } from 'events';
+import * as internalSocket from './InternalSocket';
+import { ComponentLoader } from './ComponentLoader';
+import * as utils from './Utils';
+import IP from './IP';
+import { deprecated, isBrowser } from './Platform';
 
 function connectPort(socket, process, port, index, inbound, callback) {
   if (inbound) {
@@ -72,12 +72,11 @@ function sendInitial(initial) {
 // instantiate all the necessary processes from the designated
 // components, attach sockets between them, and handle the sending
 // of Initial Information Packets.
-class BaseNetwork extends EventEmitter {
+export class BaseNetwork extends EventEmitter {
   // All NoFlo networks are instantiated with a graph. Upon instantiation
   // they will load all the needed components, instantiate them, and
   // set up the defined connections and IIPs.
-  constructor(graph, options) {
-    if (options == null) { options = {}; }
+  constructor(graph, options = {}) {
     super();
     this.options = options;
     // Processes contains all the instantiated components for this network
@@ -101,7 +100,8 @@ class BaseNetwork extends EventEmitter {
     if (graph.properties.baseDir && !options.baseDir) {
       deprecated('Passing baseDir via Graph properties is deprecated, pass via Network options instead');
     }
-    if (!platform.isBrowser()) {
+    this.baseDir = null;
+    if (!isBrowser()) {
       this.baseDir = options.baseDir || graph.properties.baseDir || process.cwd();
     // On browser we default the baseDir to the Component loading
     // root
@@ -115,13 +115,14 @@ class BaseNetwork extends EventEmitter {
     this.startupDate = null;
 
     // Initialize a Component Loader for the network
+    this.loader = null;
     if (options.componentLoader) {
       this.loader = options.componentLoader;
     } else if (graph.properties.componentLoader) {
       deprecated('Passing componentLoader via Graph properties is deprecated, pass via Network options instead');
       this.loader = graph.properties.componentLoader;
     } else {
-      this.loader = new componentLoader.ComponentLoader(this.baseDir, this.options);
+      this.loader = new ComponentLoader(this.baseDir, this.options);
     }
 
     // Enable Flowtrace for this network, when available
@@ -792,7 +793,7 @@ class BaseNetwork extends EventEmitter {
         return;
       }
       if (process.component.start.length === 0) {
-        platform.deprecated('component.start method without callback is deprecated');
+        deprecated('component.start method without callback is deprecated');
         process.component.start();
         onProcessStart();
         return;
@@ -823,7 +824,7 @@ class BaseNetwork extends EventEmitter {
 
   start(callback) {
     if (!callback) {
-      platform.deprecated('Calling network.start() without callback is deprecated');
+      deprecated('Calling network.start() without callback is deprecated');
       callback = () => {};
     }
 
@@ -866,7 +867,7 @@ class BaseNetwork extends EventEmitter {
 
   stop(callback) {
     if (!callback) {
-      platform.deprecated('Calling network.stop() without callback is deprecated');
+      deprecated('Calling network.stop() without callback is deprecated');
       callback = () => {};
     }
 
@@ -913,7 +914,7 @@ class BaseNetwork extends EventEmitter {
         return;
       }
       if (process.component.shutdown.length === 0) {
-        platform.deprecated('component.shutdown method without callback is deprecated');
+        deprecated('component.shutdown method without callback is deprecated');
         process.component.shutdown();
         onProcessEnd();
         return;
@@ -1000,5 +1001,3 @@ class BaseNetwork extends EventEmitter {
     });
   }
 }
-
-module.exports = BaseNetwork;

--- a/src/lib/BaseNetwork.js
+++ b/src/lib/BaseNetwork.js
@@ -73,9 +73,17 @@ function sendInitial(initial) {
 // components, attach sockets between them, and handle the sending
 // of Initial Information Packets.
 export class BaseNetwork extends EventEmitter {
-  // All NoFlo networks are instantiated with a graph. Upon instantiation
-  // they will load all the needed components, instantiate them, and
-  // set up the defined connections and IIPs.
+  /**
+   * All NoFlo networks are instantiated with a graph. Upon instantiation
+   * they will load all the needed components, instantiate them, and
+   * set up the defined connections and IIPs.
+   *
+   * @param {import("fbp-graph").Graph} graph - Graph definition to build a Network for
+   * @param {Object} options - Network options
+   * @param {string} [options.baseDir] - Project base directory for component loading
+   * @param {ComponentLoader} [options.componentLoader] - Component loader instance to use, if any
+   * @param {Object} [options.flowtrace] - Flowtrace instance to use for tracing this network run
+   */
   constructor(graph, options = {}) {
     super();
     this.options = options;

--- a/src/lib/BasePort.js
+++ b/src/lib/BasePort.js
@@ -1,7 +1,7 @@
 //     NoFlo - Flow-Based Programming for JavaScript
 //     (c) 2014-2017 Flowhub UG
 //     NoFlo may be freely distributed under the MIT license
-const { EventEmitter } = require('events');
+import { EventEmitter } from 'events';
 
 // ## NoFlo Port Base class
 //
@@ -77,7 +77,7 @@ function handleOptions(options) {
   });
 }
 
-module.exports = class BasePort extends EventEmitter {
+export default class BasePort extends EventEmitter {
   constructor(options) {
     super();
     // Options holds all options of the current port
@@ -186,4 +186,4 @@ module.exports = class BasePort extends EventEmitter {
 
   /* eslint-disable class-methods-use-this */
   canAttach() { return true; }
-};
+}

--- a/src/lib/Component.js
+++ b/src/lib/Component.js
@@ -10,7 +10,7 @@
 */
 import { EventEmitter } from 'events';
 import debug from 'debug';
-import * as ports from './Ports';
+import { InPorts, OutPorts, normalizePortName } from './Ports';
 import ProcessContext from './ProcessContext';
 import ProcessInput from './ProcessInput';
 import ProcessOutput from './ProcessOutput';
@@ -19,12 +19,34 @@ const debugComponent = debug('noflo:component');
 const debugBrackets = debug('noflo:component:brackets');
 const debugSend = debug('noflo:component:send');
 
+/**
+ * @callback ProcessingFunction
+ * @param {ProcessInput} input
+ * @param {ProcessOutput} output
+ * @param {ProcessContext} context
+ * @returns {void}
+ */
+
 // ## NoFlo Component Base class
 //
 // The `noflo.Component` interface provides a way to instantiate
 // and extend NoFlo components.
 export class Component extends EventEmitter {
-  constructor(options = {}) {
+  /**
+   * @param {Object} options
+   * @param {Object | InPorts} [options.inPorts] - Inports for the component
+   * @param {Object | OutPorts} [options.outPorts] - Outports for the component
+   * @param {string} [options.icon]
+   * @param {string} [options.description]
+   * @param {ProcessingFunction} [options.process] - Component processsing function
+   * @param {boolean} [options.ordered] - Whether component should send
+   * packets in same order it received them
+   * @param {boolean} [options.autoOrdering]
+   * @param {boolean} [options.activateOnInput] - Whether component should
+   * activate when it receives packets
+   * @param {Object} [options.forwardBrackets] - Mappings of ports to forward brackets to
+   */
+  constructor(options = { }) {
     super();
     const opts = options;
     // Prepare inports, if any were given in options.
@@ -32,10 +54,10 @@ export class Component extends EventEmitter {
     // instantiation by using the `component.inPorts.add`
     // method.
     if (!opts.inPorts) { opts.inPorts = {}; }
-    if (opts.inPorts instanceof ports.InPorts) {
+    if (opts.inPorts instanceof InPorts) {
       this.inPorts = opts.inPorts;
     } else {
-      this.inPorts = new ports.InPorts(opts.inPorts);
+      this.inPorts = new InPorts(opts.inPorts);
     }
 
     // Prepare outports, if any were given in opts.
@@ -43,10 +65,10 @@ export class Component extends EventEmitter {
     // instantiation by using the `component.outPorts.add`
     // method.
     if (!opts.outPorts) { opts.outPorts = {}; }
-    if (opts.outPorts instanceof ports.OutPorts) {
+    if (opts.outPorts instanceof OutPorts) {
       this.outPorts = opts.outPorts;
     } else {
-      this.outPorts = new ports.OutPorts(opts.outPorts);
+      this.outPorts = new OutPorts(opts.outPorts);
     }
 
     // Set the default component icon and description
@@ -91,6 +113,8 @@ export class Component extends EventEmitter {
 
     // Placeholder for the ID of the current node, populated
     // by NoFlo network
+    //
+    /** @type string | null */
     this.nodeId = null;
   }
 
@@ -100,6 +124,9 @@ export class Component extends EventEmitter {
 
   isSubgraph() { return false; }
 
+  /**
+   * @param {string} icon - Updated icon for the component
+   */
   setIcon(icon) {
     this.icon = icon;
     this.emit('icon', this.icon);
@@ -112,6 +139,12 @@ export class Component extends EventEmitter {
   // If component has an `error` outport that is connected, errors
   // are sent as IP objects there. If the port is not connected,
   // errors are thrown.
+  /**
+   * @param {Error} e
+   * @param {Array} [groups]
+   * @param {string} [errorPort]
+   * @param {string | null} [scope]
+   */
   error(e, groups = [], errorPort = 'error', scope = null) {
     if (this.outPorts[errorPort]
       && (this.outPorts[errorPort].isAttached() || !this.outPorts[errorPort].isRequired())) {
@@ -123,6 +156,11 @@ export class Component extends EventEmitter {
     throw e;
   }
 
+  /**
+   * @callback ErrorableCallback
+   * @param {Error | null} error
+   */
+
   // ### Setup
   //
   // The setUp method is for component-specific initialization.
@@ -130,28 +168,37 @@ export class Component extends EventEmitter {
   //
   // Override in component implementation to do component-specific
   // setup work.
+  /**
+   * @param {ErrorableCallback} callback - Callback for when setup is ready
+   */
   setUp(callback) {
-    callback();
+    callback(null);
   }
 
-  // ### Setup
+  // ### Teardown
   //
   // The tearDown method is for component-specific cleanup. Called
   // at network shutdown
   //
   // Override in component implementation to do component-specific
   // cleanup work, like clearing any accumulated state.
+  /**
+   * @param {ErrorableCallback} callback - Callback for when teardown is ready
+   */
   tearDown(callback) {
-    callback();
+    callback(null);
   }
 
   // ### Start
   //
   // Called when network starts. This sets calls the setUp
   // method and sets the component to a started state.
+  /**
+   * @param {ErrorableCallback} callback - Callback for when startup is ready
+   */
   start(callback) {
     if (this.isStarted()) {
-      callback();
+      callback(null);
       return;
     }
     this.setUp((err) => {
@@ -173,6 +220,9 @@ export class Component extends EventEmitter {
   //
   // The callback is called when tearDown finishes and
   // all active processing contexts have ended.
+  /**
+   * @param {ErrorableCallback} callback - Callback for when shutdown is ready
+   */
   shutdown(callback) {
     const finalize = () => {
       // Clear contents of inport buffers
@@ -188,12 +238,12 @@ export class Component extends EventEmitter {
         out: {},
       };
       if (!this.isStarted()) {
-        callback();
+        callback(null);
         return;
       }
       this.started = false;
       this.emit('end');
-      callback();
+      callback(null);
     };
 
     // Tell the component that it is time to shut down
@@ -248,6 +298,10 @@ export class Component extends EventEmitter {
   }
 
   // Sets process handler function
+  /**
+   * @param {ProcessingFunction} handle - Processing function
+   * @returns {Component}
+   */
   process(handle) {
     if (typeof handle !== 'function') {
       throw new Error('Process handler must be a function');
@@ -392,7 +446,7 @@ export class Component extends EventEmitter {
 
   // Get the current bracket forwarding context for an IP object
   getBracketContext(type, port, scope, idx) {
-    let { name, index } = ports.normalizePortName(port);
+    let { name, index } = normalizePortName(port);
     if (idx != null) { index = idx; }
     const portsList = type === 'in' ? this.inPorts : this.outPorts;
     if (portsList[name].isAddressable()) {
@@ -415,7 +469,7 @@ export class Component extends EventEmitter {
   addToResult(result, port, packet, before = false) {
     const res = result;
     const ip = packet;
-    const { name, index } = ports.normalizePortName(port);
+    const { name, index } = normalizePortName(port);
     const method = before ? 'unshift' : 'push';
     if (this.outPorts[name].isAddressable()) {
       const idx = index ? parseInt(index, 10) : ip.index;
@@ -432,7 +486,7 @@ export class Component extends EventEmitter {
   // Get contexts that can be forwarded with this in/outport
   // pair.
   getForwardableContexts(inport, outport, contexts) {
-    const { name, index } = ports.normalizePortName(outport);
+    const { name, index } = normalizePortName(outport);
     const forwardable = [];
     contexts.forEach((ctx, idx) => {
       // No forwarding to this outport

--- a/src/lib/Component.js
+++ b/src/lib/Component.js
@@ -6,22 +6,24 @@
 /* eslint-disable
     class-methods-use-this,
     no-underscore-dangle,
+    import/prefer-default-export,
 */
-const { EventEmitter } = require('events');
-const debug = require('debug')('noflo:component');
-const debugBrackets = require('debug')('noflo:component:brackets');
-const debugSend = require('debug')('noflo:component:send');
+import { EventEmitter } from 'events';
+import debug from 'debug';
+import * as ports from './Ports';
+import ProcessContext from './ProcessContext';
+import ProcessInput from './ProcessInput';
+import ProcessOutput from './ProcessOutput';
 
-const ports = require('./Ports');
-const ProcessContext = require('./ProcessContext');
-const ProcessInput = require('./ProcessInput');
-const ProcessOutput = require('./ProcessOutput');
+const debugComponent = debug('noflo:component');
+const debugBrackets = debug('noflo:component:brackets');
+const debugSend = debug('noflo:component:send');
 
 // ## NoFlo Component Base class
 //
 // The `noflo.Component` interface provides a way to instantiate
 // and extend NoFlo components.
-class Component extends EventEmitter {
+export class Component extends EventEmitter {
   constructor(options = {}) {
     super();
     const opts = options;
@@ -321,7 +323,7 @@ class Component extends EventEmitter {
     if ((ip.type === 'openBracket') && (this.autoOrdering === null) && !this.ordered) {
       // Switch component to ordered mode when receiving a stream unless
       // auto-ordering is disabled
-      debug(`${this.nodeId} port '${port.name}' entered auto-ordering mode`);
+      debugComponent(`${this.nodeId} port '${port.name}' entered auto-ordering mode`);
       this.autoOrdering = true;
     }
 
@@ -382,10 +384,10 @@ class Component extends EventEmitter {
     // If receiving an IP object didn't cause the component to
     // activate, log that input conditions were not met
     if (port.isAddressable()) {
-      debug(`${this.nodeId} packet on '${port.name}[${ip.index}]' didn't match preconditions: ${ip.type}`);
+      debugComponent(`${this.nodeId} packet on '${port.name}[${ip.index}]' didn't match preconditions: ${ip.type}`);
       return;
     }
-    debug(`${this.nodeId} packet on '${port.name}' didn't match preconditions: ${ip.type}`);
+    debugComponent(`${this.nodeId} packet on '${port.name}' didn't match preconditions: ${ip.type}`);
   }
 
   // Get the current bracket forwarding context for an IP object
@@ -615,5 +617,3 @@ class Component extends EventEmitter {
 }
 Component.description = '';
 Component.icon = null;
-
-exports.Component = Component;

--- a/src/lib/ComponentLoader.js
+++ b/src/lib/ComponentLoader.js
@@ -6,12 +6,13 @@
 /* eslint-disable
     class-methods-use-this,
     import/no-unresolved,
+    import/prefer-default-export,
 */
 
-const fbpGraph = require('fbp-graph');
-const { EventEmitter } = require('events');
-const registerLoader = require('./loader/register');
-const platform = require('./Platform');
+import { Graph } from 'fbp-graph';
+import { EventEmitter } from 'events';
+import * as registerLoader from './loader/register';
+import { deprecated } from './Platform';
 
 // ## The NoFlo Component Loader
 //
@@ -26,7 +27,7 @@ const platform = require('./Platform');
 // NPM dependencies. For browsers and embedded devices it is
 // possible to generate a statically configured component
 // loader using the [noflo-component-loader](https://github.com/noflo/noflo-component-loader) webpack plugin.
-class ComponentLoader extends EventEmitter {
+export class ComponentLoader extends EventEmitter {
   constructor(baseDir, options = {}) {
     super();
     this.baseDir = baseDir;
@@ -141,7 +142,7 @@ class ComponentLoader extends EventEmitter {
       if (typeof name === 'string') { inst.componentName = name; }
 
       if (inst.isLegacy()) {
-        platform.deprecated(`Component ${name} uses legacy NoFlo APIs. Please port to Process API`);
+        deprecated(`Component ${name} uses legacy NoFlo APIs. Please port to Process API`);
       }
 
       this.setIcon(name, inst);
@@ -199,7 +200,7 @@ class ComponentLoader extends EventEmitter {
   isGraph(cPath) {
     // Live graph instance
     if ((typeof cPath === 'object')
-      && (cPath instanceof fbpGraph.Graph
+      && (cPath instanceof Graph
         || (Array.isArray(cPath.nodes)
           && Array.isArray(cPath.edges)
           && Array.isArray(cPath.initializers)))) {
@@ -366,5 +367,3 @@ class ComponentLoader extends EventEmitter {
     this.processing = false;
   }
 }
-
-exports.ComponentLoader = ComponentLoader;

--- a/src/lib/IP.js
+++ b/src/lib/IP.js
@@ -27,7 +27,7 @@
 //   - 'openBracket'
 //   - 'closeBracket'
 
-module.exports = class IP {
+export default class IP {
   // Detects if an arbitrary value is an IP
   static isIP(obj) {
     return obj && (typeof obj === 'object') && (obj.isIP === true);
@@ -78,4 +78,4 @@ module.exports = class IP {
   drop() {
     Object.keys(this).forEach((key) => { delete this[key]; });
   }
-};
+}

--- a/src/lib/InPort.js
+++ b/src/lib/InPort.js
@@ -1,13 +1,13 @@
 //     NoFlo - Flow-Based Programming for JavaScript
 //     (c) 2014-2017 Flowhub UG
 //     NoFlo may be freely distributed under the MIT license
-const BasePort = require('./BasePort');
+import BasePort from './BasePort';
 
 // ## NoFlo inport
 //
 // Input Port (inport) implementation for NoFlo components. These
 // ports are the way a component receives Information Packets.
-module.exports = class InPort extends BasePort {
+export default class InPort extends BasePort {
   constructor(options = {}) {
     const opts = options;
     if (opts.control == null) { opts.control = false; }
@@ -205,4 +205,4 @@ module.exports = class InPort extends BasePort {
   clear() {
     return this.prepareBuffer();
   }
-};
+}

--- a/src/lib/InternalSocket.js
+++ b/src/lib/InternalSocket.js
@@ -2,8 +2,8 @@
 //     (c) 2013-2017 Flowhub UG
 //     (c) 2011-2012 Henri Bergius, Nemein
 //     NoFlo may be freely distributed under the MIT license
-const { EventEmitter } = require('events');
-const IP = require('./IP');
+import { EventEmitter } from 'events';
+import IP from './IP';
 
 function legacyToIp(event, payload) {
   // No need to wrap modern IP Objects
@@ -51,7 +51,7 @@ function ipToLegacy(ip) {
 // packets sent from processes' outports, and emitting corresponding
 // events so that the packets can be caught to the inport of the
 // connected process.
-class InternalSocket extends EventEmitter {
+export class InternalSocket extends EventEmitter {
   regularEmitEvent(event, data) {
     this.emit(event, data);
   }
@@ -290,6 +290,6 @@ class InternalSocket extends EventEmitter {
   }
 }
 
-exports.InternalSocket = InternalSocket;
-
-exports.createSocket = (metadata = {}) => new InternalSocket(metadata);
+export function createSocket(metadata = {}) {
+  return new InternalSocket(metadata);
+}

--- a/src/lib/LegacyNetwork.js
+++ b/src/lib/LegacyNetwork.js
@@ -2,8 +2,12 @@
 //     (c) 2013-2018 Flowhub UG
 //     (c) 2011-2012 Henri Bergius, Nemein
 //     NoFlo may be freely distributed under the MIT license
-const BaseNetwork = require('./BaseNetwork');
-const { deprecated } = require('./Platform');
+import { BaseNetwork } from './BaseNetwork';
+import { deprecated } from './Platform';
+
+/* eslint-disable
+    import/prefer-default-export,
+*/
 
 // ## The NoFlo network coordinator
 //
@@ -14,7 +18,7 @@ const { deprecated } = require('./Platform');
 // instantiate all the necessary processes from the designated
 // components, attach sockets between them, and handle the sending
 // of Initial Information Packets.
-class LegacyNetwork extends BaseNetwork {
+export class LegacyNetwork extends BaseNetwork {
   // All NoFlo networks are instantiated with a graph. Upon instantiation
   // they will load all the needed components, instantiate them, and
   // set up the defined connections and IIPs.
@@ -109,5 +113,3 @@ class LegacyNetwork extends BaseNetwork {
     });
   }
 }
-
-exports.Network = LegacyNetwork;

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -19,13 +19,6 @@ import { BaseNetwork } from './BaseNetwork';
 // components, attach sockets between them, and handle the sending
 // of Initial Information Packets.
 export class Network extends BaseNetwork {
-  // All NoFlo networks are instantiated with a graph. Upon instantiation
-  // they will load all the needed components, instantiate them, and
-  // set up the defined connections and IIPs.
-  constructor(graph, options = {}) {
-    super(graph, options);
-  }
-
   // Add a process to the network. The node will also be registered
   // with the current graph.
   addNode(node, options, callback) {

--- a/src/lib/Network.js
+++ b/src/lib/Network.js
@@ -2,10 +2,11 @@
 //     (c) 2013-2018 Flowhub UG
 //     (c) 2011-2012 Henri Bergius, Nemein
 //     NoFlo may be freely distributed under the MIT license
-const BaseNetwork = require('./BaseNetwork');
+import { BaseNetwork } from './BaseNetwork';
 
 /* eslint-disable
     no-param-reassign,
+    import/prefer-default-export,
 */
 
 // ## The NoFlo network coordinator
@@ -17,7 +18,7 @@ const BaseNetwork = require('./BaseNetwork');
 // instantiate all the necessary processes from the designated
 // components, attach sockets between them, and handle the sending
 // of Initial Information Packets.
-class Network extends BaseNetwork {
+export class Network extends BaseNetwork {
   // All NoFlo networks are instantiated with a graph. Upon instantiation
   // they will load all the needed components, instantiate them, and
   // set up the defined connections and IIPs.
@@ -148,5 +149,3 @@ class Network extends BaseNetwork {
     });
   }
 }
-
-exports.Network = Network;

--- a/src/lib/NoFlo.js
+++ b/src/lib/NoFlo.js
@@ -116,6 +116,22 @@ export { internalSocket };
 // NoFlo Information Packets are defined as "IP" objects.
 export { default as IP } from './IP';
 
+/**
+ * @callback NetworkCallback
+ * @param {Error | null} err
+ * @param {Network} [network]
+ */
+
+/**
+ * @param {import("fbp-graph").Graph} graphInstance - Graph definition to build a Network for
+ * @param {Object} options - Network options
+ * @param {string} [options.baseDir] - Project base directory for component loading
+ * @param {import("./ComponentLoader").ComponentLoader} [options.componentLoader]
+ * @param {Object} [options.flowtrace] - Flowtrace instance to use for tracing this network run
+ * @param {boolean} [options.subscribeGraph] - Whether the Network should monitor the graph
+ * @param {boolean} [options.delay] - Whether the Network should be started later
+ * @param {NetworkCallback} callback - Callback for the created Network
+ */
 export function createNetwork(graphInstance, options, callback) {
   if (typeof options !== 'object') {
     options = {};

--- a/src/lib/NoFlo.js
+++ b/src/lib/NoFlo.js
@@ -10,6 +10,7 @@
 
 /* eslint-disable
     no-param-reassign,
+    import/first
 */
 
 // ## Main APIs
@@ -17,56 +18,7 @@
 // ### Graph interface
 //
 // [fbp-graph](https://github.com/flowbased/fbp-graph) is used for instantiating FBP graph definitions.
-const fbpGraph = require('fbp-graph');
-
-exports.graph = fbpGraph.graph;
-exports.Graph = fbpGraph.Graph;
-
-// ### Graph journal
-//
-// Journal is used for keeping track of graph changes
-exports.journal = fbpGraph.journal;
-exports.Journal = fbpGraph.Journal;
-
-// ### Platform detection
-//
-// NoFlo works on both Node.js and the browser. Because some dependencies are different,
-// we need a way to detect which we're on.
-exports.isBrowser = require('./Platform').isBrowser;
-
-// ### Component Loader
-//
-// The [ComponentLoader](../ComponentLoader/) is responsible for finding and loading
-// NoFlo components. Component Loader uses [fbp-manifest](https://github.com/flowbased/fbp-manifest)
-// to find components and graphs by traversing the NPM dependency tree from a given root
-// directory on the file system.
-exports.ComponentLoader = require('./ComponentLoader').ComponentLoader;
-
-// ### Component baseclasses
-//
-// These baseclasses can be used for defining NoFlo components.
-exports.Component = require('./Component').Component;
-
-// ### NoFlo ports
-//
-// These classes are used for instantiating ports on NoFlo components.
-const ports = require('./Ports');
-
-exports.InPorts = ports.InPorts;
-exports.OutPorts = ports.OutPorts;
-exports.InPort = require('./InPort');
-exports.OutPort = require('./OutPort');
-
-// ### NoFlo sockets
-//
-// The NoFlo [internalSocket](InternalSocket.html) is used for connecting ports of
-// different components together in a network.
-exports.internalSocket = require('./InternalSocket');
-
-// ### Information Packets
-//
-// NoFlo Information Packets are defined as "IP" objects.
-exports.IP = require('./IP');
+import { graph } from 'fbp-graph';
 
 // ## Network instantiation
 //
@@ -113,11 +65,58 @@ exports.IP = require('./IP');
 //
 // The options object can also be used for setting ComponentLoader options in this
 // network.
-const { Network } = require('./Network');
-const { Network: LegacyNetwork } = require('./LegacyNetwork');
-const { deprecated } = require('./Platform');
+import { Network } from './Network';
+import { LegacyNetwork } from './LegacyNetwork';
+import { deprecated } from './Platform';
 
-exports.createNetwork = function createNetwork(graph, options, callback) {
+export {
+  graph,
+  Graph,
+  journal,
+  Journal,
+} from 'fbp-graph';
+
+// ### Platform detection
+//
+// NoFlo works on both Node.js and the browser. Because some dependencies are different,
+// we need a way to detect which we're on.
+export { isBrowser } from './Platform';
+
+// ### Component Loader
+//
+// The [ComponentLoader](../ComponentLoader/) is responsible for finding and loading
+// NoFlo components. Component Loader uses [fbp-manifest](https://github.com/flowbased/fbp-manifest)
+// to find components and graphs by traversing the NPM dependency tree from a given root
+// directory on the file system.
+export { ComponentLoader } from './ComponentLoader';
+
+// ### Component baseclasses
+//
+// These baseclasses can be used for defining NoFlo components.
+export { Component } from './Component';
+
+// ### NoFlo ports
+//
+// These classes are used for instantiating ports on NoFlo components.
+export { InPorts, OutPorts } from './Ports';
+
+export { default as InPort } from './InPort';
+export { default as OutPort } from './OutPort';
+
+// ### NoFlo sockets
+//
+// The NoFlo [internalSocket](InternalSocket.html) is used for connecting ports of
+// different components together in a network.
+import * as internalSocket from './InternalSocket';
+
+export { internalSocket };
+
+// ### Information Packets
+//
+// NoFlo Information Packets are defined as "IP" objects.
+export { default as IP } from './IP';
+
+export function createNetwork(graphInstance, options, callback) {
   if (typeof options !== 'object') {
     options = {};
   }
@@ -134,7 +133,7 @@ exports.createNetwork = function createNetwork(graph, options, callback) {
   // Choose legacy or modern network based on whether graph
   // subscription is needed
   const NetworkType = options.subscribeGraph ? LegacyNetwork : Network;
-  const network = new NetworkType(graph, options);
+  const network = new NetworkType(graphInstance, options);
 
   const networkReady = (net) => { // Send IIPs
     net.start((err) => {
@@ -160,7 +159,7 @@ exports.createNetwork = function createNetwork(graph, options, callback) {
     }
 
     // Empty network, no need to connect it up
-    if (graph.nodes.length === 0) {
+    if (graphInstance.nodes.length === 0) {
       networkReady(network);
       return;
     }
@@ -175,7 +174,7 @@ exports.createNetwork = function createNetwork(graph, options, callback) {
     });
   });
   return network;
-};
+}
 
 // ### Starting a network from a file
 //
@@ -188,7 +187,7 @@ exports.createNetwork = function createNetwork(graph, options, callback) {
 //       }
 //       console.log('Network is now running!');
 //     })
-exports.loadFile = function loadFile(file, options, callback) {
+export function loadFile(file, options, callback) {
   if (typeof callback !== 'function') {
     deprecated('Calling noflo.loadFile without a callback is deprecated');
     callback = (err) => {
@@ -196,24 +195,21 @@ exports.loadFile = function loadFile(file, options, callback) {
     };
   }
 
-  exports.graph.loadFile(file, (err, graph) => {
+  graph.loadFile(file, (err, graphInstance) => {
     if (err) {
       callback(err);
       return;
     }
-    if (options.baseDir) {
-      graph.properties.baseDir = options.baseDir;
-    }
-    exports.createNetwork(graph, options, callback);
+    createNetwork(graphInstance, options, callback);
   });
-};
+}
 
 // ### Saving a network definition
 //
 // NoFlo graph files can be saved back into the filesystem with this method.
-exports.saveFile = function saveFile(graph, file, callback) {
-  graph.save(file, callback);
-};
+export function saveFile(graphInstance, file, callback) {
+  graphInstance.save(file, callback);
+}
 
 // ## Embedding NoFlo in existing JavaScript code
 //
@@ -230,7 +226,7 @@ exports.saveFile = function saveFile(graph, file, callback) {
 //       // Do something with results
 //     });
 //
-exports.asCallback = require('./AsCallback').asCallback;
+export { asCallback } from './AsCallback';
 
 // ## Generating components from JavaScript functions
 //
@@ -244,4 +240,4 @@ exports.asCallback = require('./AsCallback').asCallback;
 //       });
 //     };
 //
-exports.asComponent = require('./AsComponent').asComponent;
+export { asComponent } from './AsComponent';

--- a/src/lib/OutPort.js
+++ b/src/lib/OutPort.js
@@ -1,8 +1,8 @@
 //     NoFlo - Flow-Based Programming for JavaScript
 //     (c) 2014-2017 Flowhub UG
 //     NoFlo may be freely distributed under the MIT license
-const BasePort = require('./BasePort');
-const IP = require('./IP');
+import BasePort from './BasePort';
+import IP from './IP';
 
 // ## NoFlo outport
 //
@@ -18,7 +18,7 @@ const IP = require('./IP');
  * @property {boolean} [scoped=true]
  */
 
-module.exports = class OutPort extends BasePort {
+export default class OutPort extends BasePort {
   /**
    * @param {OutportOptions} options - Options for the outport
    */
@@ -161,4 +161,4 @@ module.exports = class OutPort extends BasePort {
     }
     return false;
   }
-};
+}

--- a/src/lib/Ports.js
+++ b/src/lib/Ports.js
@@ -2,9 +2,9 @@
 //     NoFlo - Flow-Based Programming for JavaScript
 //     (c) 2014-2017 Flowhub UG
 //     NoFlo may be freely distributed under the MIT license
-const { EventEmitter } = require('events');
-const InPort = require('./InPort');
-const OutPort = require('./OutPort');
+import { EventEmitter } from 'events';
+import InPort from './InPort';
+import OutPort from './OutPort';
 
 // NoFlo ports collections
 //
@@ -59,7 +59,7 @@ class Ports extends EventEmitter {
   }
 }
 
-exports.InPorts = class InPorts extends Ports {
+export class InPorts extends Ports {
   constructor(ports) {
     super(ports, InPort);
   }
@@ -73,9 +73,9 @@ exports.InPorts = class InPorts extends Ports {
     if (!this.ports[name]) { throw new Error(`Port ${name} not available`); }
     return this.ports[name].once(event, callback);
   }
-};
+}
 
-exports.OutPorts = class OutPorts extends Ports {
+export class OutPorts extends Ports {
   constructor(ports) {
     super(ports, OutPort);
   }
@@ -104,12 +104,12 @@ exports.OutPorts = class OutPorts extends Ports {
     if (!this.ports[name]) { throw new Error(`Port ${name} not available`); }
     this.ports[name].disconnect(socketId);
   }
-};
+}
 
 // Port name normalization:
 // returns object containing keys name and index for ports names in
 // format `portname` or `portname[index]`.
-exports.normalizePortName = function normalizePortName(name) {
+export function normalizePortName(name) {
   const port = { name };
   // Regular port
   if (name.indexOf('[') === -1) { return port; }
@@ -120,4 +120,4 @@ exports.normalizePortName = function normalizePortName(name) {
     name: matched[1],
     index: matched[2],
   };
-};
+}

--- a/src/lib/ProcessContext.js
+++ b/src/lib/ProcessContext.js
@@ -3,7 +3,7 @@
 //     (c) 2011-2012 Henri Bergius, Nemein
 //     NoFlo may be freely distributed under the MIT license
 
-module.exports = class ProcessContext {
+export default class ProcessContext {
   constructor(ip, nodeInstance, port, result) {
     this.ip = ip;
     this.nodeInstance = nodeInstance;
@@ -27,4 +27,4 @@ module.exports = class ProcessContext {
     if (!this.result.__resolved) { this.result.__resolved = true; }
     this.nodeInstance.deactivate(this);
   }
-};
+}

--- a/src/lib/ProcessInput.js
+++ b/src/lib/ProcessInput.js
@@ -3,9 +3,11 @@
 //     (c) 2011-2012 Henri Bergius, Nemein
 //     NoFlo may be freely distributed under the MIT license
 /* eslint-disable no-underscore-dangle */
-const debug = require('debug')('noflo:component');
+import debug from 'debug';
 
-module.exports = class ProcessInput {
+const debugComponent = debug('noflo:component');
+
+export default class ProcessInput {
   constructor(ports, context) {
     this.ports = ports;
     this.context = context;
@@ -26,9 +28,9 @@ module.exports = class ProcessInput {
     }
     this.nodeInstance.activate(this.context);
     if (this.port.isAddressable()) {
-      debug(`${this.nodeInstance.nodeId} packet on '${this.port.name}[${this.ip.index}]' caused activation ${this.nodeInstance.load}: ${this.ip.type}`);
+      debugComponent(`${this.nodeInstance.nodeId} packet on '${this.port.name}[${this.ip.index}]' caused activation ${this.nodeInstance.load}: ${this.ip.type}`);
     } else {
-      debug(`${this.nodeInstance.nodeId} packet on '${this.port.name}' caused activation ${this.nodeInstance.load}: ${this.ip.type}`);
+      debugComponent(`${this.nodeInstance.nodeId} packet on '${this.port.name}' caused activation ${this.nodeInstance.load}: ${this.ip.type}`);
     }
   }
 
@@ -300,4 +302,4 @@ module.exports = class ProcessInput {
     if (args.length === 1) { return datas.pop(); }
     return datas;
   }
-};
+}

--- a/src/lib/ProcessOutput.js
+++ b/src/lib/ProcessOutput.js
@@ -4,9 +4,10 @@
 //     NoFlo may be freely distributed under the MIT license
 
 /* eslint-disable no-underscore-dangle */
-const debug = require('debug')('noflo:component');
+import debug from 'debug';
+import IP from './IP';
 
-const IP = require('./IP');
+const debugComponent = debug('noflo:component');
 
 // Checks if a value is an Error
 function isError(err) {
@@ -14,7 +15,7 @@ function isError(err) {
     || (Array.isArray(err) && (err.length > 0) && err[0] instanceof Error);
 }
 
-module.exports = class ProcessOutput {
+export default class ProcessOutput {
   constructor(ports, context) {
     this.ports = ports;
     this.context = context;
@@ -168,8 +169,8 @@ module.exports = class ProcessOutput {
       });
     }
 
-    debug(`${this.nodeInstance.nodeId} finished processing ${this.nodeInstance.load}`);
+    debugComponent(`${this.nodeInstance.nodeId} finished processing ${this.nodeInstance.load}`);
 
     this.nodeInstance.deactivate(this.context);
   }
-};
+}

--- a/src/lib/loader/NodeJs.js
+++ b/src/lib/loader/NodeJs.js
@@ -4,12 +4,11 @@
     no-underscore-dangle,
     prefer-destructuring,
 */
-const path = require('path');
-const fs = require('fs');
-const manifest = require('fbp-manifest');
-const fbpGraph = require('fbp-graph');
-
-const utils = require('../Utils');
+import * as path from 'path';
+import * as fs from 'fs';
+import * as manifest from 'fbp-manifest';
+import * as fbpGraph from 'fbp-graph';
+import * as utils from '../Utils';
 
 // Type loading CoffeeScript compiler
 let CoffeeScript;
@@ -146,16 +145,16 @@ function transpileAndRegisterForModule(loader, module, component, source, langua
   });
 }
 
-exports.setSource = function setSource(loader, packageId, name, source, language, callback) {
+export function setSource(loader, packageId, name, source, language, callback) {
   transpileAndRegisterForModule(loader, {
     name: packageId,
     base: '',
   }, {
     name,
   }, source, language, callback);
-};
+}
 
-exports.getSource = function getSource(loader, name, callback) {
+export function getSource(loader, name, callback) {
   let componentName = name;
   let component = loader.components[name];
   if (!component) {
@@ -268,9 +267,9 @@ exports.getSource = function getSource(loader, name, callback) {
       code,
     });
   });
-};
+}
 
-exports.getLanguages = function getLanguages() {
+export function getLanguages() {
   const languages = ['javascript', 'es2015'];
   if (CoffeeScript) {
     languages.push('coffeescript');
@@ -279,7 +278,7 @@ exports.getLanguages = function getLanguages() {
     languages.push('typescript');
   }
   return languages;
-};
+}
 
 function registerCustomLoaders(loader, componentLoaders, callback) {
   if (!componentLoaders.length) {
@@ -434,7 +433,7 @@ function registerSubgraph(loader) {
   loader.registerComponent(null, 'Graph', graphPath);
 }
 
-exports.register = function register(loader, callback) {
+export function register(loader, callback) {
   const manifestOptions = manifestLoader.prepareManifestOptions(loader);
 
   if (loader.options != null ? loader.options.cache : undefined) {
@@ -457,9 +456,9 @@ exports.register = function register(loader, callback) {
     registerSubgraph(loader);
     callback(null, modules);
   });
-};
+}
 
-exports.dynamicLoad = function dynamicLoad(name, cPath, metadata, callback) {
+export function dynamicLoad(name, cPath, metadata, callback) {
   let implementation; let instance;
   try {
     implementation = require(cPath);
@@ -488,4 +487,4 @@ exports.dynamicLoad = function dynamicLoad(name, cPath, metadata, callback) {
   }
   if (typeof name === 'string') { instance.componentName = name; }
   callback(null, instance);
-};
+}

--- a/src/lib/loader/register.js
+++ b/src/lib/loader/register.js
@@ -1,10 +1,10 @@
 /* eslint-disable
     global-require,
 */
-const { isBrowser } = require('../Platform');
+import { isBrowser } from '../Platform';
 
 if (isBrowser()) {
   throw new Error('Generate NoFlo component loader for browsers with noflo-component-loader');
-} else {
-  module.exports = require('./NodeJs');
 }
+
+export * from './NodeJs';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,15 +4,18 @@
     "module": "commonjs",
     "allowJs": true,
     "checkJs": true,
-    "declaration": true,
-    "outDir": "./lib",
+    "outDir": ".",
     "declaration": true,
     "strict": false,
-    "rootDir": "."
+    "rootDir": "src"
   },
   "include": [
     "src/*.ts",
     "src/**/*.js",
     "src/lib/**/*.js"
+  ],
+  "exclude": [
+    "lib/*.js",
+    "components/*.js"
   ]
 }


### PR DESCRIPTION
Instead of using tsc for type checking and babel for transpilation to releasable module, this uses tsc for both.

* Using ES6 modules in `src`
* Exposing type definitions in the NoFlo package

If we want, we can improve the type defs [via JsDoc](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html)