### PR TITLE
Make it possible to choose whether async means end of same loop, or next

### DIFF
--- a/src/lib/BaseNetwork.js
+++ b/src/lib/BaseNetwork.js
@@ -900,7 +900,7 @@ export class BaseNetwork extends EventEmitter {
    */
   sendInitials() {
     return new Promise((resolve) => {
-      makeAsync(resolve);
+      makeAsync(resolve, true);
     })
       .then(() => this.initials.reduce((chain, initial) => chain
         .then(() => {

--- a/src/lib/Platform.js
+++ b/src/lib/Platform.js
@@ -41,12 +41,17 @@ export function deprecated(message) {
  * @param {Function} func
  * @returns {void}
  */
-export function makeAsync(func) {
+export function makeAsync(func, sameLoop = false) {
   if (isBrowser()) {
+    // FIXME: Browsers don't have setImmediate yet so can't do same loop
     setTimeout(func, 0);
     return;
   }
-  setImmediate(() => {
-    func();
-  });
+  if (sameLoop) {
+    setImmediate(() => {
+      func();
+    });
+    return;
+  }
+  process.nextTick(func);
 }


### PR DESCRIPTION
#694

Based on this comment: https://github.com/noflo/noflo/pull/700#issuecomment-743305295

For browsers, various hacks would be possible. But skipping those for now https://github.com/YuzuJS/setImmediate